### PR TITLE
Minor text tweak for docs mentioning color

### DIFF
--- a/tests/dummy/app/templates/public-pages/docs/how-to-use-it.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/how-to-use-it.hbs
@@ -62,7 +62,7 @@
 {{/code-sample}}
 
 <p>
-  You can see that the calendar shows the selected date in a different shade of gray. Besides, you might also have noticed that
+  You can see that the calendar shows the selected date in blue. Besides, you might also have noticed that
   the despite just passing a <code>selected</code> option, the month is not the current one. That is because, in the
   absence of a specific <code>center</code>, the calendar will show the month of the selected date. But take into account
   that if both options are provided, <code>center</code> <strong>always</strong> prevails.


### PR DESCRIPTION
The description of `selected` mentioned that the selected date was shown in a shade of grey. At least with the current styles, it's blue.