### PR TITLE
[WIP] Use moment day names

### DIFF
--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -10,7 +10,9 @@ export default Component.extend({
   focusedId: null,
   showDaysAround: true,
   clockService: service('power-calendar-clock'),
-  dayNamesAbbrs: moment.weekdaysShort(),
+  dayNamesAbbrs: computed(function() {
+    return moment.weekdaysShort();
+  }),
 
   // CPs
   startOfWeek: computed({

--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -3,13 +3,14 @@ import layout from '../../templates/components/power-calendar/days';
 import computed from 'ember-computed';
 import service from 'ember-service/inject';
 import { scheduleOnce } from 'ember-runloop';
+import moment from 'moment';
 
 export default Component.extend({
   layout,
   focusedId: null,
   showDaysAround: true,
   clockService: service('power-calendar-clock'),
-  dayNamesAbbrs: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  dayNamesAbbrs: moment.weekdaysShort(),
 
   // CPs
   startOfWeek: computed({

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,10 @@
 /*jshint node:true*/
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
-  return { };
+module.exports = function(environment) {
+  return {
+    moment: {
+      includeLocales: true
+    }
+  };
 };

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -551,3 +551,31 @@ test('When the user tries to focus a disabled date with the down arrow key, the 
   assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-15"]').hasClass('ember-power-calendar-day--focused'));
   assert.equal(document.activeElement, this.$('.ember-power-calendar-day[data-date="2013-10-15"]').get(0));
 });
+
+test('If is used default moment language, it should show the weekdays in english', function(assert) {
+  assert.expect(1);
+  this.render(hbs`
+    {{#power-calendar center=center as |calendar|}}
+      {{calendar.nav}}
+      {{calendar.days}}
+    {{/power-calendar}}
+  `);
+
+  let weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  assert.equal(this.$('.ember-power-calendar-weekday').text().replace(/\s/g, ''), weekDays.join(''), 'The week days should be in english');
+});
+
+test('If is used "pt" as moment language, it should show the weekdays in Portuguese', function(assert) {
+  assert.expect(1);
+  moment.locale('pt');
+
+  this.render(hbs`
+    {{#power-calendar center=center as |calendar|}}
+      {{calendar.nav}}
+      {{calendar.days}}
+    {{/power-calendar}}
+  `);
+
+  let weekDays = ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom'];
+  assert.equal(this.$('.ember-power-calendar-weekday').text().replace(/\s/g, ''), weekDays.join(''), 'The week days should be in english');
+});


### PR DESCRIPTION
This allows to use directly the dates from moment.

It's going to include into the [build the locales](https://github.com/stefanpenner/ember-moment#include-all-locales-into-build) but maybe would be interesting to have a custom **localeOutputPath**. What do you think?

Also, might beinteresting to have i18n as a dependency and on _i18n.locale_ change, recompute the _dayNamesAbbrs_ ?
