### PR TITLE
added type='button' to days to not trigger form submit

### DIFF
--- a/addon/templates/components/power-calendar/days.hbs
+++ b/addon/templates/components/power-calendar/days.hbs
@@ -12,6 +12,7 @@
       <div class="ember-power-calendar-row ember-power-calendar-week">
         {{#each week.days key='id' as |day|}}
           <button
+            type="button"
             data-date="{{day.id}}"
             class="ember-power-calendar-day ember-power-calendar-day--interactive {{if day.isCurrentMonth 'ember-power-calendar-day--current-month' 'ember-power-calendar-day--other-month'}} {{if day.isSelected 'ember-power-calendar-day--selected'}} {{if day.isToday 'ember-power-calendar-day--today'}} {{if day.isFocused 'ember-power-calendar-day--focused'}} {{if day.isRangeStart 'ember-power-calendar-day--range-start'}} {{if day.isRangeEnd 'ember-power-calendar-day--range-end'}}"
             onclick={{action calendar.actions.select day}}


### PR DESCRIPTION
when including ember-power-calendar in a form selecting a day triggers form submission. added `<button type="button">` to override the default `type="submit"`