### PR TITLE
[BREAKING] Rename `changeCenter` to `moveCenter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+- [BREAKING] Rename `calendar.actions.changeCenter` to `calendar.actions.moveCenter`.
 - [BUGFIX] Clicking on the last selected day selected it twice instead of removing it.
 
 ## 0.1.4

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -8,7 +8,7 @@ import { task } from 'ember-concurrency';
 export default Component.extend({
   layout,
   classNames: ['ember-power-calendar'],
-  classNameBindings: ['changeCenterTask.isRunning:ember-power-calendar--loading'],
+  classNameBindings: ['moveCenterTask.isRunning:ember-power-calendar--loading'],
   clockService: service('power-calendar-clock'),
   momentService: service('moment'),
   navComponent: 'power-calendar/nav',
@@ -18,7 +18,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     this.publicActions = {
-      changeCenter: (...args) => this.get('changeCenterTask').perform(...args),
+      moveCenter: (...args) => this.get('moveCenterTask').perform(...args),
       select: (...args) => this.send('select', ...args)
     };
   },
@@ -51,7 +51,7 @@ export default Component.extend({
   },
 
   // Tasks
-  changeCenterTask: task(function* (step, unit) {
+  moveCenterTask: task(function* (step, unit) {
     let center = this.get('center');
     let momentDate = moment(center);
     let month = momentDate.clone().add(step, unit);

--- a/addon/templates/components/power-calendar/nav.hbs
+++ b/addon/templates/components/power-calendar/nav.hbs
@@ -1,6 +1,6 @@
 <nav class="ember-power-calendar-nav">
   {{#if onCenterChange}}
-    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--previous" onclick={{action calendar.actions.changeCenter -1 'month'}}>«</button>
+    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--previous" onclick={{action calendar.actions.moveCenter -1 'month'}}>«</button>
   {{/if}}
   <div class="ember-power-calendar-nav-title">
     {{#if hasBlock}}
@@ -10,6 +10,6 @@
     {{/if}}
   </div>
   {{#if onCenterChange}}
-    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--next" onclick={{action calendar.actions.changeCenter 1 'month'}}>»</button>
+    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--next" onclick={{action calendar.actions.moveCenter 1 'month'}}>»</button>
   {{/if}}
 </nav>

--- a/tests/dummy/app/templates/components/calendar-nav-with-year-buttons.hbs
+++ b/tests/dummy/app/templates/components/calendar-nav-with-year-buttons.hbs
@@ -1,9 +1,9 @@
 <nav class="ember-power-calendar-nav">
-  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter -12 'month'}}>«</button>
-  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter -1 'month'}}>‹</button>
+  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -12 'month'}}>«</button>
+  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -1 'month'}}>‹</button>
   <div class="ember-power-calendar-nav-title">
     {{moment-format calendar.center 'MMMM YYYY'}}
   </div>
-  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter 1 'month'}}>›</button>
-  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter 12 'month'}}>»</button>
+  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter 1 'month'}}>›</button>
+  <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter 12 'month'}}>»</button>
 </nav>

--- a/tests/dummy/app/templates/snippets/the-nav-2.hbs
+++ b/tests/dummy/app/templates/snippets/the-nav-2.hbs
@@ -3,13 +3,13 @@
   onCenterChange=(action (mut month) value="date") as |calendar|}}
 
   <nav class="ember-power-calendar-nav">
-    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter -12 'month'}}>«</button>
-    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter -1 'month'}}>‹</button>
+    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -12 'month'}}>«</button>
+    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -1 'month'}}>‹</button>
     <div class="ember-power-calendar-nav-title">
       {{moment-format calendar.center 'MMMM YYYY'}}
     </div>
-    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter 1 'month'}}>›</button>
-    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.changeCenter 12 'month'}}>»</button>
+    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter 1 'month'}}>›</button>
+    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter 12 'month'}}>»</button>
   </nav>
 
   {{calendar.days}}

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -83,11 +83,11 @@ test('when it receives a `moment()` in the `center` argument, it displays that m
 test('when it receives a `center` and an `onCenterChange` action, it shows controls to go to the next & previous month and the action is called when they are clicked', function(assert) {
   assert.expect(7);
   this.center = new Date(2016, 1, 5);
-  this.changeCenter = function() {
-    assert.ok(true, 'The changeCenter action is invoked');
+  this.moveCenter = function() {
+    assert.ok(true, 'The moveCenter action is invoked');
   };
   this.render(hbs`
-    {{#power-calendar center=center onCenterChange=changeCenter as |calendar|}}
+    {{#power-calendar center=center onCenterChange=moveCenter as |calendar|}}
       {{calendar.nav}}
       {{calendar.days}}
     {{/power-calendar}}

--- a/tests/integration/components/power-calendar/days-test.js
+++ b/tests/integration/components/power-calendar/days-test.js
@@ -17,7 +17,7 @@ moduleForComponent('power-calendar', 'Integration | Component | power-calendar/d
       center: moment(calendarService.getDate()),
       locale: 'en',
       actions: {
-        changeCenter: () => {},
+        moveCenter: () => {},
         select: () => {}
       }
     };

--- a/tests/integration/components/power-calendar/nav-test.js
+++ b/tests/integration/components/power-calendar/nav-test.js
@@ -16,7 +16,7 @@ moduleForComponent('power-calendar', 'Integration | Component | power-calendar/n
     calendar = {
       center: moment(calendarService.getDate()),
       actions: {
-        changeCenter: () => {},
+        moveCenter: () => {},
         select: () => {}
       }
     };


### PR DESCRIPTION
The reason is that the action takes a unit and a number, and displaces the center from
its current position that number of units.
However, I'm going to create another action that for convenience takes a single date/moment
and just sets the center to it.