### PR TITLE
Fix classes of single-day ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+- [BUGFIX] If a range has `start` and `end` in the same day, that day has both `*--range-start` and `*--range-end` classes.
 - [BREAKING] Rename `calendar.actions.changeCenter` to `calendar.actions.moveCenter`.
 - [BUGFIX] Clicking on the last selected day selected it twice instead of removing it.
 

--- a/addon/components/power-calendar-range/days.js
+++ b/addon/components/power-calendar-range/days.js
@@ -9,7 +9,7 @@ export default DaysComponent.extend({
     if (start && end) {
       day.isSelected = dayMoment.isBetween(start, end, 'day', '[]');
       day.isRangeStart = day.isSelected && dayMoment.isSame(start, 'day');
-      day.isRangeEnd = !day.isRangeStart && dayMoment.isSame(end, 'day');
+      day.isRangeEnd = day.isSelected && dayMoment.isSame(end, 'day');
     } else {
       day.isRangeStart = day.isSelected = dayMoment.isSame(start, 'day');
       day.isRangeEnd = false;

--- a/tests/dummy/app/styles/_base.scss
+++ b/tests/dummy/app/styles/_base.scss
@@ -20,15 +20,6 @@ body {
 a {
   text-decoration: none;
   color: $link-color;
-
-  // I don't want this styles yet
-
-  // border-bottom: 1px solid rgba($link-color, 0.3);
-
-  // &:hover {
-  //   text-decoration: none;
-  //   border-bottom-color: $link-color;
-  // }
 }
 
 img, iframe {

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -70,6 +70,25 @@ test('In range calendars, clicking a day selects one end of the range, and click
   assert.equal(numberOfCalls, 2, 'The onSelect action was called twice');
 });
 
+test('The start and end of the range can be the same day', function(assert) {
+  this.range = null;
+  this.render(hbs`
+    {{#power-calendar-range selected=range onSelect=(action (mut range) value="moment") as |cal|}}
+      {{cal.nav}}
+      {{cal.days}}
+    {{/power-calendar-range}}
+  `);
+
+  assert.equal(this.$('.ember-power-calendar-day--selected').length, 0, 'No days have been selected');
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--selected'), 'The clicked date is selected');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-start'), 'The clicked date is the start of the range');
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--selected'), 'The first clicked date is still selected');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-start'), 'The first clicked date is still the start of the range');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-end'), 'The same day is also the end');
+});
+
 test('In range calendars, clicking first the end of the range and then the start is not a problem', function(assert) {
   this.selected = null;
   let numberOfCalls = 0;


### PR DESCRIPTION
If a day is both start and end of a range, it has the proper classes