### PR TITLE
[FEATURE] Add `minRange` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  # - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-2.5
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/addon/components/power-calendar-multiple.js
+++ b/addon/components/power-calendar-multiple.js
@@ -14,8 +14,18 @@ export default CalendarComponent.extend({
     return moment((this.get('selected') || [])[0] || this.get('clockService').getDate());
   }),
 
+  // Actions
+  actions: {
+    select(day, e) {
+      let action = this.get('onSelect');
+      if (action) {
+        action(this._buildCollection(day), e);
+      }
+    }
+  },
+
   // Methods
-  buildonSelectValue(day) {
+  _buildCollection(day) {
     let selected = this.get('publicAPI.selected') || [];
     let values = [];
     let index = -1;

--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -2,6 +2,7 @@ import CalendarComponent from './power-calendar';
 import computed from 'ember-computed';
 import moment from 'moment';
 import { getProperties } from 'ember-metal/get';
+import { assign } from 'ember-platform';
 
 export default CalendarComponent.extend({
   daysComponent: 'power-calendar-range/days',
@@ -14,6 +15,25 @@ export default CalendarComponent.extend({
       return moment(center);
     }
     return moment(this.get('selected.start') || this.get('clockService').getDate());
+  }),
+
+  minRangeDuration: computed('minRange', function() {
+    let minRange = this.get('minRange');
+    if (moment.isDuration(minRange)) {
+      return minRange;
+    }
+    if (typeof minRange === 'number') {
+      return moment.duration(minRange, 'days');
+    }
+    if (typeof minRange === 'string') {
+      let [, quantity, units] = minRange.match(/(\d+)(.*)/);
+      units = units.trim() || 'days';
+      return moment.duration(parseInt(quantity, 10), units);
+    }
+  }),
+
+  publicAPI: computed('_publicAPI', 'minRangeDuration', function() {
+    return assign({ minRange: this.get('minRangeDuration') }, this.get('_publicAPI'));
   }),
 
   // Methods
@@ -44,21 +64,6 @@ export default CalendarComponent.extend({
         moment: { start: day.moment, end: null },
         date: {  start: day.date, end: null }
       };
-    }
-  },
-
-  _buildMinRange() {
-    let minRange = this.get('minRange');
-    if (moment.isDuration(minRange)) {
-      return minRange;
-    }
-    if (typeof minRange === 'number') {
-      return moment.duration(minRange, 'days');
-    }
-    if (typeof minRange === 'string') {
-      let [, quantity, units] = minRange.match(/(\d+)(.*)/);
-      units = units.trim() || 'days';
-      return moment.duration(parseInt(quantity, 10), units);
     }
   }
 });

--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -5,6 +5,7 @@ import { getProperties } from 'ember-metal/get';
 
 export default CalendarComponent.extend({
   daysComponent: 'power-calendar-range/days',
+  minRange: moment.duration(1, 'day'),
 
   // CPs
   currentCenter: computed('center', function() {
@@ -16,6 +17,12 @@ export default CalendarComponent.extend({
   }),
 
   // Methods
+  buildPublicAPI() {
+    let publicAPI = this._super(...arguments);
+    publicAPI.minRange = this._buildMinRange();
+    return publicAPI;
+  },
+
   buildonSelectValue(day) {
     let selected = this.get('publicAPI.selected') || { start: null, end: null };
     let { start, end } = getProperties(selected, 'start', 'end');
@@ -37,6 +44,21 @@ export default CalendarComponent.extend({
         moment: { start: day.moment, end: null },
         date: {  start: day.date, end: null }
       };
+    }
+  },
+
+  _buildMinRange() {
+    let minRange = this.get('minRange');
+    if (moment.isDuration(minRange)) {
+      return minRange;
+    }
+    if (typeof minRange === 'number') {
+      return moment.duration(minRange, 'days');
+    }
+    if (typeof minRange === 'string') {
+      let [, quantity, units] = minRange.match(/(\d+)(.*)/);
+      units = units.trim() || 'days';
+      return moment.duration(parseInt(quantity, 10), units);
     }
   }
 });

--- a/addon/components/power-calendar-range/days.js
+++ b/addon/components/power-calendar-range/days.js
@@ -11,8 +11,13 @@ export default DaysComponent.extend({
       day.isRangeStart = day.isSelected && dayMoment.isSame(start, 'day');
       day.isRangeEnd = day.isSelected && dayMoment.isSame(end, 'day');
     } else {
-      day.isRangeStart = day.isSelected = dayMoment.isSame(start, 'day');
       day.isRangeEnd = false;
+      if (!start) {
+        day.isRangeStart = false;
+      } else {
+        day.isRangeStart = day.isSelected = dayMoment.isSame(start, 'day');
+        day.isDisabled = day.isDisabled || Math.abs(day.moment.diff(start)) < calendar.minRange.as('ms');
+      }
     }
     return day;
   },

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -14,6 +14,7 @@ export default Component.extend({
   navComponent: 'power-calendar/nav',
   daysComponent: 'power-calendar/days',
   center: null,
+
   // Lifecycle chooks
   init() {
     this._super(...arguments);
@@ -52,7 +53,7 @@ export default Component.extend({
     select(day, e) {
       let action = this.get('onSelect');
       if (action) {
-        action(this.buildonSelectValue(day), e);
+        action(day, e);
       }
     }
   },
@@ -60,10 +61,5 @@ export default Component.extend({
   // Tasks
   changeCenterTask: task(function* (newCenterMoment) {
     yield this.get('onCenterChange')({ date: newCenterMoment.toDate(), moment: newCenterMoment });
-  }),
-
-  // Methods
-  buildonSelectValue(day) {
-    return day;
-  }
+  })
 });

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -34,10 +34,20 @@ export default Component.extend({
     return moment(this.get('selected') || this.get('clockService').getDate());
   }),
 
-  publicAPI: computed('selected', 'currentCenter', 'locale', 'momentService.locale', function() {
-    return this.buildPublicAPI();
+  publicAPI: computed('_publicAPI', function() {
+    return this.get('_publicAPI');
   }),
 
+  _publicAPI: computed('selected', 'currentCenter', 'locale', 'momentService.locale', function() {
+    return {
+      selected: this.get('selected'),
+      center: this.get('currentCenter'),
+      locale: this.get('locale') || this.get('momentService.locale'),
+      actions: this.get('publicActions')
+    };
+  }),
+
+  // Actions
   actions: {
     select(day, e) {
       let action = this.get('onSelect');
@@ -53,15 +63,6 @@ export default Component.extend({
   }),
 
   // Methods
-  buildPublicAPI() {
-    return {
-      selected: this.get('selected'),
-      center: this.get('currentCenter'),
-      locale: this.get('locale') || this.get('momentService.locale'),
-      actions: this.get('publicActions')
-    };
-  },
-
   buildonSelectValue(day) {
     return day;
   }

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -35,12 +35,7 @@ export default Component.extend({
   }),
 
   publicAPI: computed('selected', 'currentCenter', 'locale', 'momentService.locale', function() {
-    return {
-      selected: this.get('selected'),
-      center: this.get('currentCenter'),
-      locale: this.get('locale') || this.get('momentService.locale'),
-      actions: this.get('publicActions')
-    };
+    return this.buildPublicAPI();
   }),
 
   actions: {
@@ -58,6 +53,15 @@ export default Component.extend({
   }),
 
   // Methods
+  buildPublicAPI() {
+    return {
+      selected: this.get('selected'),
+      center: this.get('currentCenter'),
+      locale: this.get('locale') || this.get('momentService.locale'),
+      actions: this.get('publicActions')
+    };
+  },
+
   buildonSelectValue(day) {
     return day;
   }

--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -55,7 +55,7 @@ export default Component.extend({
     return weekdaysNames.slice(localeStartOfWeek).concat(weekdaysNames.slice(0, localeStartOfWeek));
   }),
 
-  days: computed('calendar.{center,selected}', 'focusedId', 'localeStartOfWeek', 'minDate', 'maxDate', function() {
+  days: computed('calendar', 'focusedId', 'localeStartOfWeek', 'minDate', 'maxDate', function() {
     let today = this.get('clockService').getDate();
     let calendar = this.get('calendar');
     let lastDay = this.lastDay(calendar);

--- a/addon/templates/components/power-calendar.hbs
+++ b/addon/templates/components/power-calendar.hbs
@@ -1,7 +1,4 @@
-{{yield (hash
-  center=(readonly currentCenter)
-  selected=(readonly selected)
-  nav=(component navComponent calendar=(readonly publicAPI))
-  days=(component daysComponent calendar=(readonly publicAPI))
-  actions=publicAPI.actions
-)}}
+{{yield (assign publicAPI (hash
+  nav=(component navComponent calendar=(readonly publicAPI) onCenterChange=(readonly onCenterChange))
+  days=(component daysComponent calendar=(readonly publicAPI) onSelect=(readonly onSelect))
+))}}

--- a/addon/templates/components/power-calendar.hbs
+++ b/addon/templates/components/power-calendar.hbs
@@ -1,13 +1,7 @@
 {{yield (hash
   center=(readonly currentCenter)
   selected=(readonly selected)
-  nav=(component navComponent
-    calendar=(readonly publicAPI)
-    onCenterChange=(readonly onCenterChange)
-  )
-  days=(component daysComponent
-    calendar=(readonly publicAPI)
-    onSelect=(readonly onSelect)
-  )
+  nav=(component navComponent calendar=(readonly publicAPI))
+  days=(component daysComponent calendar=(readonly publicAPI))
   actions=publicAPI.actions
 )}}

--- a/app/styles/ember-power-calendar.scss
+++ b/app/styles/ember-power-calendar.scss
@@ -88,6 +88,13 @@
   background-color: lighten(#0078c9, 50%);
   color: #656D78;
 }
+.ember-power-calendar-day--selected.ember-power-calendar-day--range-start,
+.ember-power-calendar-day--selected.ember-power-calendar-day--range-end {
+  background-color: lighten(#0078c9, 40%);
+  &:hover {
+    background-color: lighten(#0078c9, 40%);
+  }
+}
 .ember-power-calendar-day--focused {
   box-shadow: inset 0px -2px 0px 0px #0078c9;
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,14 +1,25 @@
 /*jshint node:true*/
 module.exports = {
   scenarios: [
+    // {
+    //   name: 'ember-2.5',
+    //   bower: {
+    //     dependencies: {
+    //       'ember': 'components/ember#lts-2-4'
+    //     },
+    //     resolutions: {
+    //       'ember': 'lts-2-4'
+    //     }
+    //   }
+    // },
     {
-      name: 'ember-lts-2.4',
+      name: 'ember-2.5',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-4'
+          'ember': '2.5.0'
         },
         resolutions: {
-          'ember': 'lts-2-4'
+          'ember': '2.5.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
+    "ember-assign-helper": "0.1.1",
     "ember-basic-dropdown": "0.16.3",
     "ember-cli": "^2.10.0-beta.1",
     "ember-cli-app-version": "^2.0.0",

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -98,10 +98,12 @@
 
 .demo-range-calendar-with-pretty-range-ends-yo {
   .ember-power-calendar-day--range-start {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpolygon points='0,0 8,0 10,5 8,10 0,10' fill='%237dcaff'/%3E%3C/svg%3E");
+    color: white;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpolygon points='0,0 8,0 10,5 8,10 0,10' fill='%230078c9'/%3E%3C/svg%3E");
   }
   .ember-power-calendar-day--range-end {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpolygon points='0,5 2,0 10,0 10,10 2,10' fill='%237dcaff'/%3E%3C/svg%3E");
+    color: white;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpolygon points='0,5 2,0 10,0 10,10 2,10' fill='%230078c9'/%3E%3C/svg%3E");
   }
 }
 
@@ -152,5 +154,10 @@
     line-height: 1.6;
     font-family: 'Open sans', sans-serif;
     color: $text-color;
+  }
+}
+.single-day-range-demo {
+  .ember-power-calendar-day--range-start.ember-power-calendar-day--range-end {
+    color: red;
   }
 }

--- a/tests/dummy/app/templates/public-pages/docs/range-selection.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/range-selection.hbs
@@ -42,6 +42,53 @@
 
 <p>Hey, I never said I was a brilliant designer! But you get the idea.</p>
 
+<h3>The <code>minRange</code> option</h3>
+
+<p>
+  Usually the only restriction in ranges is that they have to start in one day and end in a different day,
+  but sometimes you want to be more restrictive, so the <code>minRange</code> covers this.
+</p>
+
+<p>
+  This option accepts a <code>moment.duration</code> object, a <code>number</code> or a <code>string</code>.
+  The default minimum range is one day, so the range has to start in a different date from where it begins.
+</p>
+
+<p>If you want to force the user to pick a range of at least 3 days you can just pass a number:</p>
+
+{{#code-sample hbs="range-selection-3.hbs" as |partialName|}}
+  {{partial partialName}}
+{{/code-sample}}
+
+<p>
+  Notice that once you select one end of the range the days that cannot be selected are disabled automatically.
+</p>
+
+<p>
+  This property accepts humanized durations which make it very nice to use with different units other thay days.
+  Let's make the range be of at least one week.
+</p>
+
+{{#code-sample hbs="range-selection-4.hbs" as |partialName|}}
+  {{partial partialName}}
+{{/code-sample}}
+
+<p>
+  As you'd expect, you can also use the abbreviations accepted by <code>MomentJs</code>
+</p>
+
+{{#code-sample hbs="range-selection-5.hbs" as |partialName|}}
+  {{partial partialName}}
+{{/code-sample}}
+
+<p>
+  If you want to allow ranges to begin and end on the same day, pass <code>0</code>.
+</p>
+
+{{#code-sample hbs="range-selection-6.hbs" as |partialName|}}
+  {{partial partialName}}
+{{/code-sample}}
+
 <p>
   Now let's see how to select several non-consecutive dates.
 </p>

--- a/tests/dummy/app/templates/snippets/range-selection-3.hbs
+++ b/tests/dummy/app/templates/snippets/range-selection-3.hbs
@@ -1,0 +1,9 @@
+{{#power-calendar-range
+  center=center
+  selected=mediumRange
+  minRange=3
+  onCenterChange=(action (mut center) value="date")
+  onSelect=(action (mut mediumRange) value="moment") as |cal|}}
+  {{cal.nav}}
+  {{cal.days}}
+{{/power-calendar-range}}

--- a/tests/dummy/app/templates/snippets/range-selection-4.hbs
+++ b/tests/dummy/app/templates/snippets/range-selection-4.hbs
@@ -1,0 +1,9 @@
+{{#power-calendar-range
+  center=center
+  selected=largeRange
+  minRange="1 week"
+  onCenterChange=(action (mut center) value="date")
+  onSelect=(action (mut largeRange) value="moment") as |cal|}}
+  {{cal.nav}}
+  {{cal.days}}
+{{/power-calendar-range}}

--- a/tests/dummy/app/templates/snippets/range-selection-5.hbs
+++ b/tests/dummy/app/templates/snippets/range-selection-5.hbs
@@ -1,0 +1,9 @@
+{{#power-calendar-range
+  center=center
+  selected=largeRange
+  minRange="1w"
+  onCenterChange=(action (mut center) value="date")
+  onSelect=(action (mut largeRange) value="moment") as |cal|}}
+  {{cal.nav}}
+  {{cal.days}}
+{{/power-calendar-range}}

--- a/tests/dummy/app/templates/snippets/range-selection-6.hbs
+++ b/tests/dummy/app/templates/snippets/range-selection-6.hbs
@@ -1,0 +1,12 @@
+{{#power-calendar-range
+  class="single-day-range-demo"
+  selected=minimalRange
+  minRange=0
+  onSelect=(action (mut minimalRange) value="moment") as |cal|}}
+  {{cal.nav}}
+  {{cal.days}}
+{{/power-calendar-range}}
+<small>
+  To help visualize it in this demo the color of the days when range starts and ends in the same
+  day is red.
+</small>

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -2,6 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import getOwner from 'ember-owner/get';
 import run from 'ember-runloop';
+import moment from 'moment';
 
 moduleForComponent('power-calendar-range', 'Integration | Component | power calendar range', {
   integration: true,
@@ -70,25 +71,6 @@ test('In range calendars, clicking a day selects one end of the range, and click
   assert.equal(numberOfCalls, 2, 'The onSelect action was called twice');
 });
 
-test('The start and end of the range can be the same day', function(assert) {
-  this.range = null;
-  this.render(hbs`
-    {{#power-calendar-range selected=range onSelect=(action (mut range) value="moment") as |cal|}}
-      {{cal.nav}}
-      {{cal.days}}
-    {{/power-calendar-range}}
-  `);
-
-  assert.equal(this.$('.ember-power-calendar-day--selected').length, 0, 'No days have been selected');
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--selected'), 'The clicked date is selected');
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-start'), 'The clicked date is the start of the range');
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--selected'), 'The first clicked date is still selected');
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-start'), 'The first clicked date is still the start of the range');
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-end'), 'The same day is also the end');
-});
-
 test('In range calendars, clicking first the end of the range and then the start is not a problem', function(assert) {
   this.selected = null;
   let numberOfCalls = 0;
@@ -154,4 +136,63 @@ test('Passing `minRange` allows to determine the minimum length of a range (in d
   let allDaysInBetweenAreSelected = this.$('.ember-power-calendar-day[data-date="2013-10-11"]').hasClass('ember-power-calendar-day--selected')
     && this.$('.ember-power-calendar-day[data-date="2013-10-12"]').hasClass('ember-power-calendar-day--selected');
   assert.ok(allDaysInBetweenAreSelected, 'the 11th and 12th day are selected');
+});
+
+test('Passing `minRange=0` allows to make a range start and end on the same date', function(assert) {
+  assert.expect(7);
+  this.render(hbs`
+    {{#power-calendar-range selected=selected onSelect=(action (mut selected) value="date") minRange=0 as |cal|}}
+      {{cal.nav}}
+      {{cal.days}}
+    {{/power-calendar-range}}
+  `);
+
+  assert.equal(this.$('.ember-power-calendar-day--selected').length, 0, 'No days have been selected');
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').prop('disabled'), 'The clicked day is still enabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--selected'), 'The clicked date is selected');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-start'), 'The clicked date is the start of the range');
+
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--selected'), 'The clicked date is selected');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-start'), 'The clicked date is the start of the range');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').hasClass('ember-power-calendar-day--range-end'), 'The clicked date is also the end of the range');
+});
+
+test('The default minRange is one day, but it can be changed passing convenient strings', function(assert) {
+  assert.expect(4);
+  this.render(hbs`
+    {{#power-calendar-range minRange=minRange as |calendar|}}
+      <div class="formatted-min-range">{{moment-duration calendar.minRange}}</div>
+    {{/power-calendar-range}}
+  `);
+
+  assert.equal(this.$('.formatted-min-range').text().trim(), 'a day', 'the default minRange is one day');
+  run(() => this.set('minRange', 3));
+  assert.equal(this.$('.formatted-min-range').text().trim(), '3 days', 'when passed a number, it is interpreted as number of days');
+  run(() => this.set('minRange', '1 week'));
+  assert.equal(this.$('.formatted-min-range').text().trim(), '7 days', 'it can regognize humanized durations');
+  run(() => this.set('minRange', '1m'));
+  assert.equal(this.$('.formatted-min-range').text().trim(), 'a minute', 'it can regognize humanized durations that use abbreviations');
+});
+
+test('If `publicAPI.action.select` does not invoke the `onSelect` action if the range is smaller than the minRange', function(assert) {
+  assert.expect(2);
+  this.selected = { start: new Date(2016, 1, 5), end: null };
+  this.invalidDay = { date: new Date(2016, 1, 6), moment: moment(new Date(2016, 1, 6)) };
+  this.validDay = { date: new Date(2016, 1, 8), moment: moment(new Date(2016, 1, 8)) };
+  let range;
+  this.didSelect = function(r) {
+    range = r;
+  };
+  this.render(hbs`
+    {{#power-calendar-range selected=selected onSelect=didSelect minRange=2 as |cal|}}
+      <button id="select-invalid-range-end" onclick={{action cal.actions.select invalidDay}}>Select invalid date</button>
+      <button id="select-valid-range-end" onclick={{action cal.actions.select validDay}}>Select valid date</button>
+    {{/power-calendar-range}}
+  `);
+  run(() => this.$('#select-invalid-range-end').get(0).click());
+  assert.equal(range, undefined, 'The actions has not been called');
+  run(() => this.$('#select-valid-range-end').get(0).click());
+  assert.notEqual(range, undefined, 'The actions has been called now');
 });

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -127,3 +127,31 @@ test('In range calendars, clicking first the end of the range and then the start
   assert.ok(allDaysInBetweenAreSelected, 'All days in between are also selected');
   assert.equal(numberOfCalls, 2, 'The onSelect action was called twice');
 });
+
+test('Passing `minRange` allows to determine the minimum length of a range (in days)', function(assert) {
+  assert.expect(10);
+  this.render(hbs`
+    {{#power-calendar-range selected=selected onSelect=(action (mut selected) value="date") minRange=3 as |cal|}}
+      {{cal.nav}}
+      {{cal.days}}
+    {{/power-calendar-range}}
+  `);
+
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-10"]').get(0).click());
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-10"]').prop('disabled'), 'The clicked day is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-11"]').prop('disabled'), 'The next day is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-12"]').prop('disabled'), 'The next-next day is disabled too');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-13"]').prop('disabled'), 'The next-next-next day is enabled');
+
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-09"]').prop('disabled'), 'The prev day is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-08"]').prop('disabled'), 'The prev-prev day is disabled too');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-07"]').prop('disabled'), 'The prev-prev-prev day is enabled');
+
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-12"]').get(0).click());
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-12"]').hasClass('ember-power-calendar-day--selected'), 'Clicking a day not long enough didn\'t select anything');
+  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-13"]').get(0).click());
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-13"]').hasClass('ember-power-calendar-day--selected'), 'Clicking outside the range select it');
+  let allDaysInBetweenAreSelected = this.$('.ember-power-calendar-day[data-date="2013-10-11"]').hasClass('ember-power-calendar-day--selected')
+    && this.$('.ember-power-calendar-day[data-date="2013-10-12"]').hasClass('ember-power-calendar-day--selected');
+  assert.ok(allDaysInBetweenAreSelected, 'the 11th and 12th day are selected');
+});


### PR DESCRIPTION
Already working. Needs documentations before merging.

Example usage:

```hbs
{{#power-calendar minRange=3 as |cal|}} {{!-- Min range is three days --}}
{{#power-calendar minRange=0 as |cal|}} {{!-- Min range is 0 days, so the range can start and end on the same day --}}
{{#power-calendar minRange="48 hours" as |cal|}} {{!-- Range can be expressed as an humanized string --}}
{{#power-calendar minRange="1w" as |cal|}} {{!-- and can use abbreviations! --}}
``` 