### PR TITLE
Fix calendar when the `moment` global has a different locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+- [BUGFIX] Fix calculation of days when the `moment` global had a different locale than the `service:moment`.
+
 ## 0.1.6
 - [BUGFIX] Make `ember-assign-helper` a runtime dependency.
 

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -43,7 +43,7 @@ export default Component.extend({
     return {
       selected: this.get('selected'),
       center: this.get('currentCenter'),
-      locale: this.get('locale') || this.get('momentService.locale'),
+      locale: this.get('locale') || this.get('momentService.locale') || moment.locale(),
       actions: this.get('publicActions')
     };
   }),

--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -192,7 +192,7 @@ export default Component.extend({
   firstDay(calendar) {
     let firstDay = calendar.center.clone().startOf('month');
     let localeStartOfWeek = this.get('localeStartOfWeek');
-    while (firstDay.weekday() !== localeStartOfWeek) {
+    while ((firstDay.isoWeekday() % 7) !== localeStartOfWeek) {
       firstDay.add(-1, 'day');
     }
     return firstDay;
@@ -201,7 +201,8 @@ export default Component.extend({
   lastDay(calendar) {
     let localeStartOfWeek = this.get('localeStartOfWeek');
     let lastDay = calendar.center.clone().endOf('month');
-    while (lastDay.weekday() !== (localeStartOfWeek + 6) % 7) {
+    let localeEndOfWeek = (localeStartOfWeek + 6) % 7;
+    while ((lastDay.isoWeekday() % 7) !== localeEndOfWeek) {
       lastDay.add(1, 'day');
     }
     return lastDay;

--- a/tests/integration/components/power-calendar/days-test.js
+++ b/tests/integration/components/power-calendar/days-test.js
@@ -29,11 +29,22 @@ moduleForComponent('power-calendar', 'Integration | Component | power-calendar/d
   }
 });
 
-test('[i18n] The name of the weekdays respect the locale set in moment.js', function(assert) {
+test('[i18n] The name of the weekdays respect the locale set in the moment service', function(assert) {
   assert.expect(1);
   run(() => momentService.changeLocale('pt'));
   this.render(hbs`{{#power-calendar as |cal|}}{{cal.days}}{{/power-calendar}}`);
   assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'Seg Ter Qua Qui Sex Sáb Dom');
+});
+
+test('[i18n] The name of the weekdays respect the locale set in the `moment` global', function(assert) {
+  assert.expect(2);
+  this.center = new Date(2016, 10, 15);
+  let originalLocale = moment.locale();
+  moment.locale('fr');
+  this.render(hbs`{{#power-calendar center=center as |cal|}}{{cal.days}}{{/power-calendar}}`);
+  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'lun. mar. mer. jeu. ven. sam. dim.');
+  assert.equal(this.$('.ember-power-calendar-day:eq(0)').data('date'), '2016-10-31');
+  moment.locale(originalLocale);
 });
 
 test('[i18n] The user can force a different locale from the one set in moment.js passing `locale="some-locale"`', function(assert) {


### PR DESCRIPTION
Closes #36