### PR TITLE
Fix weeks id in days component

### DIFF
--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -78,7 +78,7 @@ export default Component.extend({
         daysOfWeek = daysOfWeek.filter((d) => d.isCurrentMonth);
       }
       weeks.push({
-        id: days[0].moment.format('YYYY-w'),
+        id: days[i].moment.format('YYYY-w'),
         days: daysOfWeek,
         missingDays: 7 - daysOfWeek.length
       });

--- a/tests/unit/components/power-calendar/days-test.js
+++ b/tests/unit/components/power-calendar/days-test.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import moment from 'moment';
+
+moduleForComponent('power-calendar/days', 'Unit | Component | power calendar/days', {
+  needs: ['service:power-calendar-clock'],
+  unit: true
+});
+
+test('It sets the weeks id correctly', function(assert) {
+  let component = this.subject({
+    calendar: {
+      center: moment(new Date(2013, 9, 18))
+    }
+  });
+  assert.equal(component.get('weeks.4.id'), '2013-44', 'The weeks id is set correctly');
+});


### PR DESCRIPTION
I noticed that the id in the weeks array is always the first week of the month.