### PR TITLE
[FEATURE] Allow to disable specific days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Master
 
+- [ENHANCEMENT] Allow to disable specific days passing `{{cal.days disabledDates=collection}}`.
+  As usual the property can be a collection of Dates or Moments.
+
 ## 0.2.2
 - [ENHANCEMENT] Improve default styles of calendar days.
 

--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -56,7 +56,7 @@ export default Component.extend({
     return weekdaysNames.slice(localeStartOfWeek).concat(weekdaysNames.slice(0, localeStartOfWeek));
   }),
 
-  days: computed('calendar', 'focusedId', 'localeStartOfWeek', 'minDate', 'maxDate', function() {
+  days: computed('calendar', 'focusedId', 'localeStartOfWeek', 'minDate', 'maxDate', 'disabledDates.[]', function() {
     let today = this.get('clockService').getDate();
     let calendar = this.get('calendar');
     let lastDay = this.lastDay(calendar);
@@ -165,6 +165,12 @@ export default Component.extend({
       if (!isDisabled) {
         let maxDate = this.get('maxDate');
         if (maxDate && momentDate.isAfter(maxDate)) {
+          isDisabled = true;
+        }
+      }
+      if (!isDisabled) {
+        let disabledDates = this.get('disabledDates');
+        if (disabledDates && disabledDates.some((d) => momentDate.isSame(d, 'day'))) {
           isDisabled = true;
         }
       }

--- a/tests/integration/components/power-calendar-multiple-test.js
+++ b/tests/integration/components/power-calendar-multiple-test.js
@@ -115,3 +115,34 @@ test('Clicking on a day selects it, and clicking again on it unselects it', func
   assert.equal(this.$('.ember-power-calendar-day--selected').length, 0, 'No days are selected');
 });
 
+test('If the user passes `disabledDates=someDate` to multiple calendars, days on those days are disabled', function(assert) {
+  assert.expect(13);
+  this.disabledDates = [
+    new Date(2013, 9, 15),
+    new Date(2013, 9, 17),
+    new Date(2013, 9, 21),
+    new Date(2013, 9, 23)
+  ];
+  this.render(hbs`
+    {{#power-calendar-multiple selected=selected onSelect=(action (mut selected) value="date") as |calendar|}}
+      {{calendar.nav}}
+      {{calendar.days disabledDates=disabledDates}}
+    {{/power-calendar-multiple}}
+  `);
+
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 14th is enabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-15"]').prop('disabled'), 'The 15th is disabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 16th is enabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-17"]').prop('disabled'), 'The 17th is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-21"]').prop('disabled'), 'The 21st is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-23"]').prop('disabled'), 'The 23rd is disabled');
+
+  run(() => this.set('disabledDates', [new Date(2013, 9, 22)]));
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 14th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-15"]').prop('disabled'), 'The 15th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 16th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-17"]').prop('disabled'), 'The 17th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-21"]').prop('disabled'), 'The 21st is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-23"]').prop('disabled'), 'The 23rd is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-23"]').prop('disabled'), 'The 22nd is disabled');
+});

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -431,6 +431,38 @@ test('If the user passes `maxDate=someDate` to range calendars, days after that 
   assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-16"]').prop('disabled'), 'Days after the maxDate are disabled');
 });
 
+test('If the user passes `disabledDates=someDate` to single calendars, days on those days are disabled', function(assert) {
+  assert.expect(13);
+  this.disabledDates = [
+    new Date(2013, 9, 15),
+    new Date(2013, 9, 17),
+    new Date(2013, 9, 21),
+    new Date(2013, 9, 23)
+  ];
+  this.render(hbs`
+    {{#power-calendar selected=selected onSelect=(action (mut selected) value="date") as |calendar|}}
+      {{calendar.nav}}
+      {{calendar.days disabledDates=disabledDates}}
+    {{/power-calendar}}
+  `);
+
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 14th is enabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-15"]').prop('disabled'), 'The 15th is disabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 16th is enabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-17"]').prop('disabled'), 'The 17th is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-21"]').prop('disabled'), 'The 21st is disabled');
+  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-23"]').prop('disabled'), 'The 23rd is disabled');
+
+  run(() => this.set('disabledDates', [new Date(2013, 9, 22)]));
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 14th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-15"]').prop('disabled'), 'The 15th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-14"]').prop('disabled'), 'The 16th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-17"]').prop('disabled'), 'The 17th is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-21"]').prop('disabled'), 'The 21st is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-23"]').prop('disabled'), 'The 23rd is enabled');
+  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-23"]').prop('disabled'), 'The 22nd is disabled');
+});
+
 test('When the user tries to focus a disabled date with the left arrow key, the focus stays where it is', function(assert) {
   assert.expect(4);
   this.minDate = new Date(2013, 9, 15);


### PR DESCRIPTION
The user can do that by passing `disabledDates=` to the {{cal.days}} component. Works both in single and multiple calendars, but not in range calendars because it’s clear to me what the right behaviour should be when a range contains a disabled calendar.