### PR TITLE
Fixes datepicker for new ember-basic-dropdown api

### DIFF
--- a/tests/dummy/app/templates/snippets/datepicker-1.hbs
+++ b/tests/dummy/app/templates/snippets/datepicker-1.hbs
@@ -1,6 +1,6 @@
 {{#basic-dropdown as |dropdown|}}
   <input type="text"
-    id="ember-basic-dropdown-trigger-{{dropdown.uniqueId}}"
+    data-ebd-id="{{dropdown.uniqueId}}-trigger"
     class="datepicker-demo-input"
     onclick={{dropdown.actions.toggle}}
     value={{if selected (moment-format selected 'DD-MM-YYYY')}}


### PR DESCRIPTION
With the latest ember basic dropdown, the dropdown trigger is not properly called with trigger id. It miscalculates the position of the calendar which always appear at the top left of the window. Switching to `data-ebd-id` solves this problem.