### PR TITLE
Finish migration to native-dom-helpers

### DIFF
--- a/tests/integration/components/power-calendar-multiple/days-test.js
+++ b/tests/integration/components/power-calendar-multiple/days-test.js
@@ -1,9 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import run from 'ember-runloop';
 import getOwner from 'ember-owner/get';
+import { find, click } from 'ember-native-dom-helpers';
 
-moduleForComponent('power-calendar-multiple/days', 'Integration | Component | power calendar multiple/days', {
+moduleForComponent('power-calendar-multiple/days', 'Integration | Component | power-calendar-multiple/days', {
   integration: true,
   beforeEach() {
     let calendarService = getOwner(this).lookup('service:power-calendar');
@@ -19,13 +19,13 @@ test('The maxLength property sets a maximum number of available days', function(
       {{calendar.days maxLength=1}}
     {{/power-calendar-multiple}}
   `);
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-05"]').get(0).click());
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-05"]').is(':disabled'));
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-06"]').is(':disabled'));
+  click('.ember-power-calendar-day[data-date="2013-10-05"]');
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-05"]').disabled);
+  assert.ok(find('.ember-power-calendar-day[data-date="2013-10-06"]').disabled);
 
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-05"]').get(0).click());
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-05"]').is(':disabled'));
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-06"]').is(':disabled'));
+  click('.ember-power-calendar-day[data-date="2013-10-05"]');
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-05"]').disabled);
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-06"]').disabled);
 });
 
 test('the maxLength property can handle changing of the property', function(assert) {
@@ -37,12 +37,12 @@ test('the maxLength property can handle changing of the property', function(asse
       {{calendar.days maxLength=max}}
     {{/power-calendar-multiple}}
   `);
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-05"]').get(0).click());
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-05"]').is(':disabled'));
-  assert.ok(this.$('.ember-power-calendar-day[data-date="2013-10-06"]').is(':disabled'));
+  click('.ember-power-calendar-day[data-date="2013-10-05"]');
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-05"]').disabled);
+  assert.ok(find('.ember-power-calendar-day[data-date="2013-10-06"]').disabled);
 
   this.set('max', 2);
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-06"]').is(':disabled'));
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-06"]').disabled);
 });
 
 test('maxLength can handle null for the selected days', function(assert) {
@@ -56,9 +56,9 @@ test('maxLength can handle null for the selected days', function(assert) {
       {{calendar.days maxLength=max}}
     {{/power-calendar-multiple}}
   `);
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-05"]').get(0).click());
+  click('.ember-power-calendar-day[data-date="2013-10-05"]');
   this.set('collection', null);
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-06"]').is(':disabled'));
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-06"]').disabled);
 });
 
 test('maxLength can handle null for the maxLength property', function(assert) {
@@ -71,7 +71,7 @@ test('maxLength can handle null for the maxLength property', function(assert) {
       {{calendar.days maxLength=max}}
     {{/power-calendar-multiple}}
   `);
-  run(() => this.$('.ember-power-calendar-day[data-date="2013-10-05"]').get(0).click());
+  click('.ember-power-calendar-day[data-date="2013-10-05"]');
 
-  assert.notOk(this.$('.ember-power-calendar-day[data-date="2013-10-06"]').is(':disabled'));
+  assert.notOk(find('.ember-power-calendar-day[data-date="2013-10-06"]').disabled);
 });

--- a/tests/integration/components/power-calendar/days-test.js
+++ b/tests/integration/components/power-calendar/days-test.js
@@ -4,6 +4,7 @@ import { assertionInjector, assertionCleanup } from '../../../assertions';
 import moment from 'moment';
 import run from 'ember-runloop';
 import getOwner from 'ember-owner/get';
+import { find, findAll } from 'ember-native-dom-helpers';
 
 let calendarService, momentService, calendar;
 moduleForComponent('power-calendar', 'Integration | Component | power-calendar/days', {
@@ -33,7 +34,7 @@ test('[i18n] The name of the weekdays respect the locale set in the moment servi
   assert.expect(1);
   run(() => momentService.changeLocale('pt'));
   this.render(hbs`{{#power-calendar as |cal|}}{{cal.days}}{{/power-calendar}}`);
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'Seg Ter Qua Qui Sex Sáb Dom');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'Seg Ter Qua Qui Sex Sáb Dom');
 });
 
 test('[i18n] The name of the weekdays respect the locale set in the `moment` global', function(assert) {
@@ -42,8 +43,8 @@ test('[i18n] The name of the weekdays respect the locale set in the `moment` glo
   let originalLocale = moment.locale();
   moment.locale('fr');
   this.render(hbs`{{#power-calendar center=center as |cal|}}{{cal.days}}{{/power-calendar}}`);
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'lun. mar. mer. jeu. ven. sam. dim.');
-  assert.equal(this.$('.ember-power-calendar-day:eq(0)').data('date'), '2016-10-31');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'lun. mar. mer. jeu. ven. sam. dim.');
+  assert.equal(findAll('.ember-power-calendar-day')[0].dataset.date, '2016-10-31');
   moment.locale(originalLocale);
 });
 
@@ -51,41 +52,50 @@ test('[i18n] The user can force a different locale from the one set in moment.js
   assert.expect(2);
   this.calendar = calendar;
   this.render(hbs`{{power-calendar/days calendar=calendar}}`);
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'Sun Mon Tue Wed Thu Fri Sat');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'Sun Mon Tue Wed Thu Fri Sat');
   run(() => this.set('calendar.locale', 'es'));
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'lun. mar. mié. jue. vie. sáb. dom.');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'lun. mar. mié. jue. vie. sáb. dom.');
 });
 
 test('[i18n] The it receives a `startOfWeek` option, that weekday becomes the start of the week over any default the locale might have', function(assert) {
   assert.expect(12);
+  let days;
   this.calendar = calendar;
   this.startOfWeek = '2';
   this.render(hbs`{{power-calendar/days calendar=calendar startOfWeek=startOfWeek}}`);
-  assert.equal(this.$('.ember-power-calendar-weekday:eq(0)').text().trim(), 'Tue', 'The week starts on Tuesday');
-  assert.equal(this.$('.ember-power-calendar-day:eq(0)').text().trim(), '1', 'The first day of the first week is the 1st of October');
-  assert.equal(this.$('.ember-power-calendar-day:last').text().trim(), '4', 'The last day of the last week the 4th of November');
+
+  assert.equal(findAll('.ember-power-calendar-weekday')[0].textContent.trim(), 'Tue', 'The week starts on Tuesday');
+  days = findAll('.ember-power-calendar-day');
+  assert.equal(days[0].textContent.trim(), '1', 'The first day of the first week is the 1st of October');
+  assert.equal(days[days.length - 1].textContent.trim(), '4', 'The last day of the last week the 4th of November');
+
   run(() => this.set('startOfWeek', '3'));
-  assert.equal(this.$('.ember-power-calendar-weekday:eq(0)').text().trim(), 'Wed', 'The week starts on Wednesday');
-  assert.equal(this.$('.ember-power-calendar-day:eq(0)').text().trim(), '25', 'The first day of the first week is the 25th of September');
-  assert.equal(this.$('.ember-power-calendar-day:last').text().trim(), '5', 'The last day of the last week is the 5th of November');
+  assert.equal(findAll('.ember-power-calendar-weekday')[0].textContent.trim(), 'Wed', 'The week starts on Wednesday');
+  days = findAll('.ember-power-calendar-day');
+  assert.equal(days[0].textContent.trim(), '25', 'The first day of the first week is the 25th of September');
+  assert.equal(days[days.length - 1].textContent.trim(), '5', 'The last day of the last week is the 5th of November');
+
   run(() => this.set('startOfWeek', '5'));
-  assert.equal(this.$('.ember-power-calendar-weekday:eq(0)').text().trim(), 'Fri', 'The week starts on Friday');
-  assert.equal(this.$('.ember-power-calendar-day:eq(0)').text().trim(), '27', 'The first day of the first week is the 25th of September');
-  assert.equal(this.$('.ember-power-calendar-day:last').text().trim(), '31', 'The last day of the last week is the 31th of October');
+  assert.equal(findAll('.ember-power-calendar-weekday')[0].textContent.trim(), 'Fri', 'The week starts on Friday');
+  days = findAll('.ember-power-calendar-day');
+  assert.equal(days[0].textContent.trim(), '27', 'The first day of the first week is the 25th of September');
+  assert.equal(days[days.length - 1].textContent.trim(), '31', 'The last day of the last week is the 31th of October');
+
   run(() => this.set('calendar.locale', 'pt'));
-  assert.equal(this.$('.ember-power-calendar-weekday:eq(0)').text().trim(), 'Sex', 'The week starts on Sexta Feira');
-  assert.equal(this.$('.ember-power-calendar-day:eq(0)').text().trim(), '27', 'The first day of the first week is the 25th of September');
-  assert.equal(this.$('.ember-power-calendar-day:last').text().trim(), '31', 'The last day of the last week is the 31th of October');
+  assert.equal(findAll('.ember-power-calendar-weekday')[0].textContent.trim(), 'Sex', 'The week starts on Sexta Feira');
+  days = findAll('.ember-power-calendar-day');
+  assert.equal(days[0].textContent.trim(), '27', 'The first day of the first week is the 25th of September');
+  assert.equal(days[days.length - 1].textContent.trim(), '31', 'The last day of the last week is the 31th of October');
 });
 
 test('The format of the weekdays can be changed passing `weekdayFormat="long|short|min"`', function(assert) {
   this.calendar = calendar;
   this.render(hbs`{{power-calendar/days calendar=calendar weekdayFormat=weekdayFormat}}`);
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'Sun Mon Tue Wed Thu Fri Sat');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'Sun Mon Tue Wed Thu Fri Sat');
   run(() => this.set('weekdayFormat', 'long'));
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'Sunday Monday Tuesday Wednesday Thursday Friday Saturday');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'Sunday Monday Tuesday Wednesday Thursday Friday Saturday');
   run(() => this.set('weekdayFormat', 'min'));
-  assert.equal(this.$('.ember-power-calendar-weekdays').text().replace(/\s+/g, ' ').trim(), 'Su Mo Tu We Th Fr Sa');
+  assert.equal(find('.ember-power-calendar-weekdays').textContent.replace(/\s+/g, ' ').trim(), 'Su Mo Tu We Th Fr Sa');
 });
 
 test('If it receives `showDaysAround=false` option, it doesn\'t show the days before or after the first day of the month', function(assert) {
@@ -93,14 +103,15 @@ test('If it receives `showDaysAround=false` option, it doesn\'t show the days be
   this.calendar = calendar;
   calendar.locale = 'es';
   this.render(hbs`{{power-calendar/days calendar=calendar showDaysAround=false}}`);
-  assert.equal(this.$('.ember-power-calendar-week:eq(0) .ember-power-calendar-day').length, 6, 'The first week has 6 days');
-  assert.equal(this.$('.ember-power-calendar-week:eq(0)').data('missing-days'), 1, 'It has a special data-attribute');
-  assert.equal(this.$('.ember-power-calendar-week:eq(4) .ember-power-calendar-day').length, 4, 'The last week has 4 days');
+  let weeks = findAll('.ember-power-calendar-week');
+  assert.equal(findAll('.ember-power-calendar-day', weeks[0]).length, 6, 'The first week has 6 days');
+  assert.equal(weeks[0].dataset.missingDays, 1, 'It has a special data-attribute');
+  assert.equal(findAll('.ember-power-calendar-day', weeks[4]).length, 4, 'The last week has 4 days');
 });
 
 test('It can receive `data-power-calendar-id` and it is bound to an attribute', function(assert) {
   assert.expect(1);
   this.calendar = calendar;
   this.render(hbs`{{power-calendar/days calendar=calendar data-power-calendar-id="foobar"}}`);
-  assert.equal(this.$('.ember-power-calendar-days').attr('data-power-calendar-id'), 'foobar', 'The attribute is bound');
+  assert.equal(find('.ember-power-calendar-days').dataset.powerCalendarId, 'foobar', 'The attribute is bound');
 });

--- a/tests/integration/components/power-calendar/nav-test.js
+++ b/tests/integration/components/power-calendar/nav-test.js
@@ -4,6 +4,7 @@ import { assertionInjector, assertionCleanup } from '../../../assertions';
 import moment from 'moment';
 import run from 'ember-runloop';
 import getOwner from 'ember-owner/get';
+import { find } from 'ember-native-dom-helpers';
 
 let calendarService, momentService, calendar;
 moduleForComponent('power-calendar', 'Integration | Component | power-calendar/nav', {
@@ -32,14 +33,14 @@ test('[i18n] The name of the month respect the locale set in moment.js', functio
   assert.expect(1);
   run(() => momentService.changeLocale('pt'));
   this.render(hbs`{{#power-calendar as |cal|}}{{cal.nav}}{{/power-calendar}}`);
-  assert.equal(this.$('.ember-power-calendar-nav-title').text().trim(), 'Outubro 2013');
+  assert.equal(find('.ember-power-calendar-nav-title').textContent.trim(), 'Outubro 2013');
 });
 
 test('[i18n] If the user sets a different locale in the calendar, this setting overrides the locale set in moment.js', function(assert) {
   assert.expect(2);
   this.calendar = calendar;
   this.render(hbs`{{power-calendar/nav calendar=calendar}}`);
-  assert.equal(this.$('.ember-power-calendar-nav-title').text().trim(), 'October 2013');
+  assert.equal(find('.ember-power-calendar-nav-title').textContent.trim(), 'October 2013');
   run(() => this.set('calendar.locale', 'es'));
-  assert.equal(this.$('.ember-power-calendar-nav-title').text().trim(), 'octubre 2013');
+  assert.equal(find('.ember-power-calendar-nav-title').textContent.trim(), 'octubre 2013');
 });


### PR DESCRIPTION
Still not async, but all tests use the new helpers