### PR TITLE
Set button type in nav snippet

### DIFF
--- a/tests/dummy/app/templates/snippets/the-nav-2.hbs
+++ b/tests/dummy/app/templates/snippets/the-nav-2.hbs
@@ -3,8 +3,8 @@
   onCenterChange=(action (mut month) value="date") as |calendar|}}
 
   <nav class="ember-power-calendar-nav">
-    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -12 'month'}}>«</button>
-    <button class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -1 'month'}}>‹</button>
+    <button type="button" class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -12 'month'}}>«</button>
+    <button type="button" class="ember-power-calendar-nav-control" onclick={{action calendar.actions.moveCenter -1 'month'}}>‹</button>
     <div class="ember-power-calendar-nav-title">
       {{moment-format calendar.center 'MMMM YYYY'}}
     </div>


### PR DESCRIPTION
I changed `<button>` to `<button type="submit">` in the nav snippet. 

I found an old PR and realized why changing months refreshed my page. Should the docs include an explanation on why `type="submit"` might be needed?