### PR TITLE
Fix failing test, because of not triggered focusin-event in some browsers

### DIFF
--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -555,8 +555,7 @@ module('Integration | Component | Power Calendar', function(hooks) {
       {{/power-calendar-range}}
     `);
 
-    let dayElement = find('.ember-power-calendar-day[data-date="2013-10-18"]');
-    run(() => dayElement.focus());
+    focus('.ember-power-calendar-day[data-date="2013-10-18"]');
     assert.ok(find('.ember-power-calendar-day[data-date="2013-10-18"]').classList.contains('ember-power-calendar-day--focused'));
     assert.equal(document.activeElement, find('.ember-power-calendar-day[data-date="2013-10-18"]'));
 


### PR DESCRIPTION
Hello,
if I visited http://localhost:4200/tests, the fixed test fails on Firefox. Obviously the focusin-event got not triggered, especially when dev-tools were open. I experienced the same issue at Chrome. 

Best regards