### PR TITLE
Move DOM helper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-event-dispatcher": "^0.6.3",
-    "ember-native-dom-helpers": "^0.5.4",
     "ember-power-select": "^1.10.1",
     "ember-resolver": "^4.1.0",
     "ember-source": "~2.16.2",
@@ -72,7 +71,8 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-moment-shim": "^3.5.0",
     "ember-concurrency": "^0.8.12",
-    "ember-moment": "^7.5.0"
+    "ember-moment": "^7.5.0",
+    "ember-native-dom-helpers": "^0.5.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This addresses something I brought up as a tangent in #122. When I moved the dependency from `devDependencies` to `dependencies`, it [fixed](https://travis-ci.org/backspace/ember-power-calendar-import-bug/builds/306542225) it so I didn’t need to manually `ember install ember-native-dom-helpers`.