### PR TITLE
[RFC] Select range by proximity feature

### DIFF
--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -81,7 +81,7 @@ export default CalendarComponent.extend({
     if (start && end) {
       let startMoment = moment(start);
       let endMoment = moment(end);
-      let changeStart = Math.abs(day.moment.diff(endMoment)) > Math.abs(day.moment.diff(startMoment));;
+      let changeStart = Math.abs(day.moment.diff(endMoment)) > Math.abs(day.moment.diff(startMoment));
 
       return {
         moment: { start: changeStart ? day.moment : startMoment, end: changeStart ? endMoment : day.moment },
@@ -94,7 +94,7 @@ export default CalendarComponent.extend({
         moment: { start: day.moment, end: null },
         date: { start: day.date, end: null }
       };
-    } 
+    }
 
     return this._buildDefaultRange(day, start, end);
   },
@@ -113,7 +113,7 @@ export default CalendarComponent.extend({
           date: { start: startMoment.toDate(), end: day.date }
         };
       }
-    } 
+    }
 
     return {
       moment: { start: day.moment, end: null },

--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -107,12 +107,12 @@ export default CalendarComponent.extend({
           moment: { start: day.moment, end: startMoment },
           date: { start: day.date, end: startMoment.toDate() }
         };
-      } else {
-        return {
-          moment: { start: startMoment, end: day.moment },
-          date: { start: startMoment.toDate(), end: day.date }
-        };
       }
+
+      return {
+        moment: { start: startMoment, end: day.moment },
+        date: { start: startMoment.toDate(), end: day.date }
+      };
     }
 
     return {

--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -22,6 +22,7 @@ export default CalendarComponent.extend({
   daysComponent: 'power-calendar-range/days',
   minRange: fallbackIfUndefined(moment.duration(1, 'day')),
   maxRange: fallbackIfUndefined(null),
+  proximitySelection: fallbackIfUndefined(false),
 
   // CPs
   currentCenter: computed('center', function() {
@@ -68,24 +69,55 @@ export default CalendarComponent.extend({
   _buildRange(day) {
     let selected = this.get('publicAPI.selected') || { start: null, end: null };
     let { start, end } = getProperties(selected, 'start', 'end');
+
+    if (this.get('proximitySelection')) {
+      return this._buildRangeByProximity(day, start, end);
+    }
+
+    return this._buildDefaultRange(day, start, end);
+  },
+
+  _buildRangeByProximity(day, start, end) {
+    if (start && end) {
+      let startMoment = moment(start);
+      let endMoment = moment(end);
+      let changeStart = Math.abs(day.moment.diff(endMoment)) > Math.abs(day.moment.diff(startMoment));;
+
+      return {
+        moment: { start: changeStart ? day.moment : startMoment, end: changeStart ? endMoment : day.moment },
+        date: { start: changeStart ? day.date : startMoment.toDate(), end: changeStart ? endMoment.toDate() : day.date }
+      };
+    }
+
+    if (day.moment.isBefore(moment(start))) {
+      return {
+        moment: { start: day.moment, end: null },
+        date: { start: day.date, end: null }
+      };
+    } 
+
+    return this._buildDefaultRange(day, start, end);
+  },
+
+  _buildDefaultRange(day, start, end) {
     if (start && !end) {
       let startMoment = moment(start);
       if (startMoment.isAfter(day.moment)) {
         return {
           moment: { start: day.moment, end: startMoment },
-          date: {  start: day.date, end: startMoment.toDate() }
+          date: { start: day.date, end: startMoment.toDate() }
         };
-      }  else {
+      } else {
         return {
           moment: { start: startMoment, end: day.moment },
-          date: {  start: startMoment.toDate(), end: day.date }
+          date: { start: startMoment.toDate(), end: day.date }
         };
       }
-    } else {
-      return {
-        moment: { start: day.moment, end: null },
-        date: {  start: day.date, end: null }
-      };
-    }
+    } 
+
+    return {
+      moment: { start: day.moment, end: null },
+      date: { start: day.date, end: null }
+    };
   }
 });

--- a/tests/dummy/app/templates/public-pages/docs/range-selection.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/range-selection.hbs
@@ -92,6 +92,17 @@
   {{partial partialName}}
 {{/code-example}}
 
+<h3>The <code>proximitySelection</code> option</h3>
+<p>
+  This option changes the behaviour of date selection after a choosing a start and an end date. The default behaviour
+  on the third click will select a new start date of a brand new range. With this flag enabled, once you have a range,
+  clicking a third time will move the closest of the extremes, narrowing or extending the range.
+</p>
+
+{{#code-example hbs="range-selection-7.hbs" as |partialName|}}
+  {{partial partialName}}
+{{/code-example}}
+
 <p>
   Now let's see how to select several non-consecutive dates.
 </p>

--- a/tests/dummy/app/templates/snippets/range-selection-7.hbs
+++ b/tests/dummy/app/templates/snippets/range-selection-7.hbs
@@ -1,0 +1,7 @@
+{{#power-calendar-range
+  selected=selectedRange
+  proximitySelection=true 
+  onSelect=(action (mut selectedRange) value="moment") as |cal|}}
+  {{cal.nav}}
+  {{cal.days}}
+{{/power-calendar-range}}

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -251,4 +251,31 @@ module('Integration | Component | power calendar range', function(hooks) {
     click('#select-valid-range-end');
     assert.notEqual(range, undefined, 'The actions has been called now');
   });
+
+  test('when is flagged as proximitySelection it changes range to closest date', async function(assert) {
+    assert.expect(7);
+    this.selected = { start: new Date(2016, 1, 5), end: new Date(2016, 1, 9) };
+    this.proximitySelection = true;
+
+    await render(hbs`
+      {{#power-calendar-range selected=selected onSelect=(action (mut selected) value="date") proximitySelection=true as |calendar|}}
+        {{calendar.nav}}
+        {{calendar.days}}
+      {{/power-calendar-range}}
+    `);
+    let allDaysInRangeAreSelected = find('.ember-power-calendar-day[data-date="2016-02-05"]').classList.contains('ember-power-calendar-day--selected')
+      && find('.ember-power-calendar-day[data-date="2016-02-06"]').classList.contains('ember-power-calendar-day--selected')
+      && find('.ember-power-calendar-day[data-date="2016-02-07"]').classList.contains('ember-power-calendar-day--selected')
+      && find('.ember-power-calendar-day[data-date="2016-02-08"]').classList.contains('ember-power-calendar-day--selected')
+      && find('.ember-power-calendar-day[data-date="2016-02-09"]').classList.contains('ember-power-calendar-day--selected');
+    assert.ok(allDaysInRangeAreSelected, 'All days in range are selected');
+    assert.ok(find('.ember-power-calendar-day[data-date="2016-02-05"]').classList.contains('ember-power-calendar-day--range-start'), 'The start of the range has a special class');
+    assert.ok(find('.ember-power-calendar-day[data-date="2016-02-09"]').classList.contains('ember-power-calendar-day--range-end'), 'The end of the range has a special class');
+    click('.ember-power-calendar-day[data-date="2016-02-10"]');
+    assert.ok(find('.ember-power-calendar-day[data-date="2016-02-05"]').classList.contains('ember-power-calendar-day--range-start'), 'The start of the range has a special class');
+    assert.ok(find('.ember-power-calendar-day[data-date="2016-02-10"]').classList.contains('ember-power-calendar-day--range-end'), 'The end of the range has a special class');
+    click('.ember-power-calendar-day[data-date="2016-02-04"]');
+    assert.ok(find('.ember-power-calendar-day[data-date="2016-02-04"]').classList.contains('ember-power-calendar-day--range-start'), 'The start of the range has a special class');
+    assert.ok(find('.ember-power-calendar-day[data-date="2016-02-10"]').classList.contains('ember-power-calendar-day--range-end'), 'The end of the range has a special class');
+  });
 });


### PR DESCRIPTION
So we've been using this awesome component at Uniplaces for almost a year. In the past few months we began to develop some improvements on our calendars, and this "proximity" feature was one of the most requested. Basically what we want to achieve with this is to select move dates based on the proximity of the chosen date.

For example, if you already selected the 1st of Jan as your start date and the 1st of March as your end date, if you now select the 5th of March it will only change the end date.

To accomplish this I've added a new flag to enable this behaviour.

You can check a demo here:
![exvimb7ifw](https://user-images.githubusercontent.com/17492799/38256705-d4188746-3756-11e8-8e62-6152b43e676e.gif)

Would be super cool to have this reviewed/ merged if you think it's an useful feature. Thank you!

Documentation:
![jezllvh7sr](https://user-images.githubusercontent.com/17492799/38357921-ce6db67a-38bb-11e8-8e9e-a69884a7beb4.gif)

