### PR TITLE
fix(days): prevent infinite loop for first day

### DIFF
--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -61,8 +61,9 @@ export default Component.extend({
       return parseInt(forcedStartOfWeek, 10);
     }
     let now = this.get('powerCalendarService').getDate();
-    let dayAbbr = withLocale(this.get('calendar.locale'), () => formatDate(startOf(now, 'week'), 'ddd'));
-    return this.get('weekdaysShort').indexOf(dayAbbr);
+    let day = withLocale(this.get('calendar.locale'), () => formatDate(startOf(now, 'week'), 'dddd'));
+    let idx = this.get('weekdays').indexOf(day);
+    return idx >= 0 ? idx : 0;
   }),
 
   weekdaysNames: computed('localeStartOfWeek', 'weekdayFormat', 'calendar.locale', function() {


### PR DESCRIPTION
https://github.com/cibernox/ember-power-calendar/blob/6a2845426d3c0fb92eb38ceb58663d945ef5f45c/addon/components/power-calendar/days.js#L64-L65

For `locale="de"` `dayAbbr` is `'Mo.'`, while `weekdaysShort` contains `'Mo'`. This causes an infinite loop in `firstDay`:

https://github.com/cibernox/ember-power-calendar/blob/6a2845426d3c0fb92eb38ceb58663d945ef5f45c/addon/components/power-calendar/days.js#L228-L235

This PR does two things:

- prevent infinite loops by defaulting to index `0`
- use the full name instead of abbreviations to avoid inconsistencies