### PR TITLE
Fix findCalendarElement

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,11 +1,10 @@
 import { run } from '@ember/runloop';
 import { assert } from '@ember/debug';
-import { getContext, click, settled } from '@ember/test-helpers';
+import { click, settled, find } from '@ember/test-helpers';
 import { formatDate } from 'ember-power-calendar-utils';
 
 function findCalendarElement(selector) {
-  let { element } = getContext();
-  let target = element.querySelector(selector);
+  let target = find(selector);
   if (target) {
     if (target.classList.contains('ember-power-calendar')) {
       return target;

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, click } from '@ember/test-helpers';
 import { calendarCenter, calendarSelect } from 'ember-power-calendar/test-support';
 
 module('Acceptance | helpers | calendarCenter', function(hooks) {
@@ -77,5 +77,18 @@ module('Acceptance | helpers | calendarSelect', function(hooks) {
     assert.dom('.calendar-select-1 .ember-power-calendar-nav-title').hasText('September 2013', 'The nav component has updated');
     assert.dom('.calendar-select-1 [data-date="2013-09-01"]').exists('The days component has updated');
     assert.dom('.calendar-select-1 [data-date="2013-09-03"]').hasClass('ember-power-calendar-day--selected', 'The 3rd of september is selected');
+  });
+
+  test('`calendarSelect` selects the given date in wormhole', async function(assert) {
+    await visit('/helpers-testing');
+
+    await click('.calendar-in-dropdown input');
+    assert.dom('.dropdown-content .ember-power-calendar-nav-title').hasText('October 2013');
+    assert.dom('.dropdown-content [data-date="2013-10-15"]').hasClass('ember-power-calendar-day--selected', 'The 15th is selected');
+    await calendarSelect('.dropdown-content', new Date(2013, 8, 3));
+
+    assert.dom('.dropdown-content .ember-power-calendar-nav-title').hasText('September 2013', 'The nav component has updated');
+    assert.dom('.dropdown-content [data-date="2013-09-01"]').exists('The days component has updated');
+    assert.dom('.dropdown-content [data-date="2013-09-03"]').hasClass('ember-power-calendar-day--selected', 'The 3rd of september is selected');
   });
 });

--- a/tests/dummy/app/templates/helpers-testing.hbs
+++ b/tests/dummy/app/templates/helpers-testing.hbs
@@ -49,3 +49,28 @@
     {{calendar.days}}
   {{/power-calendar}}
 </div>
+
+<div class="calendar-in-dropdown">
+  {{#basic-dropdown as |dropdown|}}
+    {{#dropdown.trigger}}
+      <input
+        value={{selected4}}
+        name="date"
+        readonly="true"
+      >
+    {{/dropdown.trigger}}
+    {{#dropdown.content
+      class="dropdown-content"
+    }}
+      {{#power-calendar
+        tagName=''
+        center=center4
+        selected=selected4
+        onSelect=(action (mut selected4) value="date")
+        onCenterChange=(action (mut center4) value="date") as |calendar|}}
+        {{calendar.nav}}
+        {{calendar.days}}
+      {{/power-calendar}}
+    {{/dropdown.content}}
+  {{/basic-dropdown}}
+</div>


### PR DESCRIPTION
- Replace 'getContext' with 'find'. It solves the issue when
  a calendar is rendered inside a wormhole.
- Add example and test for this case to helpers test.