### PR TITLE
RFC: (WIP) Override rendering a button for each day 

### DIFF
--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -30,6 +30,18 @@ const WEEK_DAYS = [
   'Sun'
 ];
 
+function classes(...args) {
+  return args.reduce((acc, arg) => {
+    if (typeof arg === 'string') return acc.concat([arg]);
+    const classes = Object.keys(arg).reduce((a, key) => {
+      if (arg[key]) return a.concat([key])
+      return a;
+    }, [])
+    return acc.concat(classes);
+  }, [])
+  .join(' ');
+}
+
 export default Component.extend({
   layout,
   focusedId: null,
@@ -181,7 +193,17 @@ export default Component.extend({
       isFocused: this.get('focusedId') === id,
       isCurrentMonth: date.getMonth() === calendar.center.getMonth(),
       isToday: isSame(date, today, 'day'),
-      isSelected: this.dayIsSelected(date, calendar)
+      isSelected: this.dayIsSelected(date, calendar),
+      classNames: classes('ember-power-calendar-day', {
+        'ember-power-calendar-day--interactive': this.get('onSelect'),
+        'ember-power-calendar-day--current-month': this.get('isCurrentMonth'),
+        'ember-power-calendar-day--other-month': !this.get('isCurrentMonth'),
+        'ember-power-calendar-day--selected': this.get('isSelected'),
+        'ember-power-calendar-day--today': this.get('isToday'),
+        'ember-power-calendar-day--focused': this.get('isFocused'),
+        'ember-power-calendar-day--range-start': this.get('isRangeStart'),
+        'ember-power-calendar-day--range-end': this.get('isRangeEnd'),
+      }),
     });
   },
 

--- a/addon/templates/components/power-calendar/days.hbs
+++ b/addon/templates/components/power-calendar/days.hbs
@@ -8,19 +8,23 @@
   {{#each weeks key='id' as |week|}}
     <div class="ember-power-calendar-row ember-power-calendar-week" data-missing-days={{week.missingDays}}>
       {{#each week.days key='id' as |day|}}
-        <button type="button"
-          data-date="{{day.id}}"
-          class={{day.classNames}}
-          onclick={{action calendar.actions.select day calendar}}
-          onfocus={{action 'onFocusDay' day}}
-          onblur={{action 'onBlurDay'}}
-          disabled={{day.isDisabled}}>
-          {{#if hasBlock}}
-            {{yield day publicAPI}}
-          {{else}}
-            {{day.number}}
-          {{/if}}
-        </button>
+        {{#if yieldAll}}
+          {{yield day publicAPI}}
+        {{else}}
+          <button type="button"
+            data-date="{{day.id}}"
+            class={{day.classNames}}
+            onclick={{action calendar.actions.select day calendar}}
+            onfocus={{action 'onFocusDay' day}}
+            onblur={{action 'onBlurDay'}}
+            disabled={{day.isDisabled}}>
+            {{#if hasBlock}}
+              {{yield day publicAPI}}
+            {{else}}
+              {{day.number}}
+            {{/if}}
+          </button>
+        {{/if}}
       {{/each}}
     </div>
   {{/each}}

--- a/addon/templates/components/power-calendar/days.hbs
+++ b/addon/templates/components/power-calendar/days.hbs
@@ -10,7 +10,7 @@
       {{#each week.days key='id' as |day|}}
         <button type="button"
           data-date="{{day.id}}"
-          class="ember-power-calendar-day {{if onSelect 'ember-power-calendar-day--interactive'}} {{if day.isCurrentMonth 'ember-power-calendar-day--current-month' 'ember-power-calendar-day--other-month'}} {{if day.isSelected 'ember-power-calendar-day--selected'}} {{if day.isToday 'ember-power-calendar-day--today'}} {{if day.isFocused 'ember-power-calendar-day--focused'}} {{if day.isRangeStart 'ember-power-calendar-day--range-start'}} {{if day.isRangeEnd 'ember-power-calendar-day--range-end'}}"
+          class={{day.classNames}}
           onclick={{action calendar.actions.select day calendar}}
           onfocus={{action 'onFocusDay' day}}
           onblur={{action 'onBlurDay'}}


### PR DESCRIPTION
I am using ep-calendar for a project I am working on. I use it to display multiple events in a day, with each event being a link to the event page.

Since ep-calendar renders a button by default for each day, I couldn't get the inner links for each event link to work reliably in Firefox (et cetera) because the button element itself would not allow clicks through to nested links. Makes sense.

I added the class names for the day to the public api and added an option to yield without rendering the button so I could construct the day from scratch in my app. Something like this might be out of the scope of your project, but I you like it, I am more than happy to change a few things to make it feel more at home and have an api you agree with. Now the API looks like this:

```hbs
<PowerCalendar as |epc|>
  {{!-- There is now a `yeildAll` argument... perhaps a better name should be used? --}}
  <epc.days @yieldAll={{true}} as |day|>
    {{#if day.isCurrentMonth}}
      {{!-- And I also yield `classNames` in the hash so they can still be applied --}}
      <div class="div-instead-of-button {{day.classNames}}">

        {{!-- The changes above mean that I can add multiple clickable things inside each day now. --}}
        <div class="events-with-clickable-buttons">
          {{#each (compute (action eventsForDate) day.date) key="id" as |event|}}
            <button class="a-button-i-can-still-click"
              onclick={{action 'goToEvent' event.id}}>
              {{ event.title }}: {{moment-format event.time 'ha'}}
            </button>
          {{/each}}
        </div>

      </div>
    {{else}}
      <div class={{day.classNames}}></div>
    {{/if}}
  </epc.days>
</PowerCalendar>
```