### PR TITLE
make unit and format configurable in nav component

### DIFF
--- a/addon/components/power-calendar/nav.js
+++ b/addon/components/power-calendar/nav.js
@@ -3,5 +3,7 @@ import layout from '../../templates/components/power-calendar/nav';
 
 export default Component.extend({
   layout,
-  tagName: ''
+  tagName: '',
+  unit: 'month',
+  format: 'MMMM YYYY'
 });

--- a/addon/templates/components/power-calendar/nav.hbs
+++ b/addon/templates/components/power-calendar/nav.hbs
@@ -1,15 +1,15 @@
 <nav class="ember-power-calendar-nav">
   {{#if calendar.actions.changeCenter}}
-    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--previous" onclick={{action calendar.actions.moveCenter -1 'month' calendar}}>«</button>
+    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--previous" onclick={{action calendar.actions.moveCenter -1 unit calendar}}>«</button>
   {{/if}}
   <div class="ember-power-calendar-nav-title">
     {{#if hasBlock}}
       {{yield calendar}}
     {{else}}
-      {{power-calendar-format-date calendar.center 'MMMM YYYY' locale=calendar.locale}}
+      {{power-calendar-format-date calendar.center format locale=calendar.locale}}
     {{/if}}
   </div>
   {{#if calendar.actions.changeCenter}}
-    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--next" onclick={{action calendar.actions.moveCenter 1 'month' calendar}}>»</button>
+    <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--next" onclick={{action calendar.actions.moveCenter 1 unit calendar}}>»</button>
   {{/if}}
 </nav>

--- a/tests/integration/components/power-calendar/nav-test.js
+++ b/tests/integration/components/power-calendar/nav-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { assertionInjector, assertionCleanup } from '../../../assertions';
 import { run } from '@ember/runloop';
@@ -19,6 +19,7 @@ module('Integration | Component | power-calendar/nav', function(hooks) {
       center: calendarService.getDate(),
       locale: 'en',
       actions: {
+        changeCenter: () => {},
         moveCenter: () => {},
         select: () => {}
       }
@@ -36,5 +37,40 @@ module('Integration | Component | power-calendar/nav', function(hooks) {
     assert.dom('.ember-power-calendar-nav-title').hasText('October 2013');
     run(() => this.set('calendar.locale', 'es'));
     assert.dom('.ember-power-calendar-nav-title').hasText('octubre 2013');
+  });
+
+  test('it can changes the date format', async function(assert) {
+    assert.expect(1);
+    this.calendar = calendar;
+    await render(hbs`{{power-calendar/nav calendar=calendar format="YYYY"}}`);
+    assert.dom('.ember-power-calendar-nav-title').hasText('2013');
+  });
+
+  test('it uses unit=month by default', async function(assert) {
+    assert.expect(1);
+    this.calendar = calendar;
+    const moved = [];
+    this.calendar.actions.moveCenter = (step, unit) => {
+      moved.push({ step, unit });
+    };
+    await render(hbs`{{power-calendar/nav calendar=calendar}}`);
+    await click('.ember-power-calendar-nav-control--previous');
+    await click('.ember-power-calendar-nav-control--next');
+
+    assert.deepEqual([ { step: -1, unit: 'month' }, { step: 1, unit: 'month' } ], moved);
+  });
+
+  test('it can changes the unit', async function(assert) {
+    assert.expect(1);
+    this.calendar = calendar;
+    const moved = [];
+    this.calendar.actions.moveCenter = (step, unit) => {
+      moved.push({ step, unit });
+    };
+    await render(hbs`{{power-calendar/nav calendar=calendar unit="year"}}`);
+    await click('.ember-power-calendar-nav-control--previous');
+    await click('.ember-power-calendar-nav-control--next');
+
+    assert.deepEqual([ { step: -1, unit: 'year' }, { step: 1, unit: 'year' } ], moved);
   });
 });


### PR DESCRIPTION
Doing a months component, adding the possibility to pass `unit` and `format` to the default nav would allow me to reuse it by passing `unit=year` and `format=YYYY`.