### PR TITLE
Power Calendar Multiple Multi Select Action

### DIFF
--- a/addon/components/power-calendar-multiple.js
+++ b/addon/components/power-calendar-multiple.js
@@ -5,6 +5,7 @@ import {
   isSame,
   normalizeMultipleActionValue
 } from 'ember-power-calendar-utils';
+import { assert } from '@ember/debug';
 
 export default CalendarComponent.extend({
   daysComponent: 'power-calendar-multiple/days',
@@ -29,30 +30,38 @@ export default CalendarComponent.extend({
 
   // Actions
   actions: {
-    select(day, calendar, e) {
+    select(dayOrDays, calendar, e) {
       let action = this.get("onSelect");
+      let days;
+      console.log(dayOrDays)
+
+      if (Array.isArray(dayOrDays)) {
+        days = dayOrDays;
+      } else if (dayOrDays instanceof Object && dayOrDays.date instanceof Date) {
+        days = [dayOrDays];
+      } else {
+        assert(`The select action expects an array of date objects, or a date object. ${typeof dayOrDays} was recieved instead.`);
+      }
+
       if (action) {
-        action(this._buildCollection(day), calendar, e);
+        action(this._buildCollection(days), calendar, e);
       }
     }
   },
 
   // Methods
-  _buildCollection(day) {
+  _buildCollection(days) {
     let selected = this.get("publicAPI.selected") || [];
-    let values = [];
-    let index = -1;
-    for (let i = 0; i < selected.length; i++) {
-      if (isSame(day.date, selected[i], "day")) {
-        index = i;
-        break;
+
+    for (const day of days) {
+      let index = selected.findIndex(selectedDate => isSame(day.date, selectedDate, "day"));
+      if (index === -1) {
+        selected = [...selected, day.date];
+      } else {
+        selected = selected.slice(0, index).concat(selected.slice(index + 1));
       }
     }
-    if (index === -1) {
-      values = [...selected, day.date];
-    } else {
-      values = selected.slice(0, index).concat(selected.slice(index + 1));
-    }
-    return normalizeMultipleActionValue({ date: values });
+
+    return normalizeMultipleActionValue({ date: selected });
   }
 });

--- a/addon/components/power-calendar-multiple.js
+++ b/addon/components/power-calendar-multiple.js
@@ -33,7 +33,6 @@ export default CalendarComponent.extend({
     select(dayOrDays, calendar, e) {
       let action = this.get("onSelect");
       let days;
-      console.log(dayOrDays)
 
       if (Array.isArray(dayOrDays)) {
         days = dayOrDays;

--- a/addon/components/power-calendar-multiple.js
+++ b/addon/components/power-calendar-multiple.js
@@ -31,6 +31,11 @@ export default CalendarComponent.extend({
   // Actions
   actions: {
     select(dayOrDays, calendar, e) {
+      assert(
+        `The select action expects an array of date objects, or a date object. ${typeof dayOrDays} was recieved instead.`, 
+        Array.isArray(dayOrDays) || dayOrDays instanceof Object && dayOrDays.date instanceof Date
+      );
+
       let action = this.get("onSelect");
       let days;
 
@@ -38,8 +43,6 @@ export default CalendarComponent.extend({
         days = dayOrDays;
       } else if (dayOrDays instanceof Object && dayOrDays.date instanceof Date) {
         days = [dayOrDays];
-      } else {
-        assert(`The select action expects an array of date objects, or a date object. ${typeof dayOrDays} was recieved instead.`);
       }
 
       if (action) {

--- a/tests/integration/components/power-calendar-multiple-test.js
+++ b/tests/integration/components/power-calendar-multiple-test.js
@@ -95,6 +95,29 @@ module('Integration | Component | power calendar multiple', function(hooks) {
     assert.dom('.ember-power-calendar-day[data-date="2013-10-09"]').hasClass('ember-power-calendar-day--selected');
   });
 
+  test('When an array of day objects are passed to the select action they are processed one at a time and added to the selected list passed to the user', async function(assert) {
+    this.datesToSelect = [
+      new Date(2013, 9, 5),
+      new Date(2013, 9, 15),
+      new Date(2013, 9, 9),
+      new Date(2013, 9, 15)
+    ].map(date => ({ date }));
+
+    this.didChange = days => {
+      assert.equal(days.date.length, 2);
+      assert.ok(isSame(days.date[0], new Date(2013, 9, 5), 'day'));
+      assert.ok(isSame(days.date[1], new Date(2013, 9, 9), 'day'));
+    };
+
+    await render(hbs`
+      {{#power-calendar-multiple selected=selected onSelect=(action didChange) as |calendar|}}
+        <button onclick={{action calendar.actions.select datesToSelect}} id="test_button"></button>
+      {{/power-calendar-multiple}}
+    `);
+
+    await click('#test_button');
+  });
+
   test('Clicking on a day selects it, and clicking again on it unselects it', async function(assert) {
     assert.expect(13);
     await render(hbs`

--- a/tests/integration/components/power-calendar-multiple-test.js
+++ b/tests/integration/components/power-calendar-multiple-test.js
@@ -48,20 +48,20 @@ module('Integration | Component | power calendar multiple', function(hooks) {
       callsCount++;
       if (callsCount === 1) {
         assert.equal(days.date.length, 1);
-        assert.ok(isSame(days.date[0], new Date('2013-10-05'), 'day'));
+        assert.ok(isSame(days.date[0], new Date(2013, 9, 5), 'day'));
       } else if (callsCount === 2) {
         assert.equal(days.date.length, 2);
-        assert.ok(isSame(days.date[0], new Date('2013-10-05'), 'day'));
-        assert.ok(isSame(days.date[1], new Date('2013-10-15'), 'day'));
+        assert.ok(isSame(days.date[0], new Date(2013, 9, 5), 'day'));
+        assert.ok(isSame(days.date[1], new Date(2013, 9, 15), 'day'));
       } else if (callsCount === 3) {
         assert.equal(days.date.length, 3);
-        assert.ok(isSame(days.date[0], new Date('2013-10-05'), 'day'));
-        assert.ok(isSame(days.date[1], new Date('2013-10-15'), 'day'));
-        assert.ok(isSame(days.date[2], new Date('2013-10-09'), 'day'));
+        assert.ok(isSame(days.date[0], new Date(2013, 9, 5), 'day'));
+        assert.ok(isSame(days.date[1], new Date(2013, 9, 15), 'day'));
+        assert.ok(isSame(days.date[2], new Date(2013, 9, 9), 'day'));
       } else {
         assert.equal(days.date.length, 2);
-        assert.ok(isSame(days.date[0], new Date('2013-10-05'), 'day'));
-        assert.ok(isSame(days.date[1], new Date('2013-10-09'), 'day'));
+        assert.ok(isSame(days.date[0], new Date(2013, 9, 5), 'day'));
+        assert.ok(isSame(days.date[1], new Date(2013, 9, 9), 'day'));
       }
       assert.isCalendar(calendar, 'The second argument is the calendar\'s public API');
       assert.ok(e instanceof Event, 'The third argument is an event');

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -516,7 +516,7 @@ module('Integration | Component | Power Calendar', function(hooks) {
     assert.dom('.ember-power-calendar-day[data-date="2013-10-15"]').isNotDisabled('The maxDate is selectable');
     assert.dom('.ember-power-calendar-day[data-date="2013-10-16"]').isDisabled('Days after the maxDate are disabled');
 
-    run(() => this.set('maxDate', new Date('2013-10-18')));
+    run(() => this.set('maxDate', new Date(2013, 9, 18)));
     assert.dom('.ember-power-calendar-day[data-date="2013-10-14"]').isNotDisabled('Days before the minDate are selectable');
     assert.dom('.ember-power-calendar-day[data-date="2013-10-18"]').isNotDisabled('The maxDate is selectable');
     assert.dom('.ember-power-calendar-day[data-date="2013-10-19"]').isDisabled('Days after the maxDate are disabled');


### PR DESCRIPTION
Allow multi select with `power-calendar-multiple` `actions.select` by passing in an array of dates.

Justification: #188