### PR TITLE
Allow Range Select to Handle Range Objects

### DIFF
--- a/addon/components/power-calendar-multiple.js
+++ b/addon/components/power-calendar-multiple.js
@@ -6,6 +6,7 @@ import {
   normalizeMultipleActionValue
 } from 'ember-power-calendar-utils';
 import { assert } from '@ember/debug';
+import { isArray } from '@ember/array';
 
 export default CalendarComponent.extend({
   daysComponent: 'power-calendar-multiple/days',
@@ -17,7 +18,7 @@ export default CalendarComponent.extend({
       return undefined;
     },
     set(_, v) {
-      return Array.isArray(v) ? v.map(normalizeDate) : v;
+      return isArray(v) ? v.map(normalizeDate) : v;
     }
   }),
   currentCenter: computed('center', function() {
@@ -33,13 +34,13 @@ export default CalendarComponent.extend({
     select(dayOrDays, calendar, e) {
       assert(
         `The select action expects an array of date objects, or a date object. ${typeof dayOrDays} was recieved instead.`, 
-        Array.isArray(dayOrDays) || dayOrDays instanceof Object && dayOrDays.date instanceof Date
+        isArray(dayOrDays) || dayOrDays instanceof Object && dayOrDays.date instanceof Date
       );
 
       let action = this.get("onSelect");
       let days;
 
-      if (Array.isArray(dayOrDays)) {
+      if (isArray(dayOrDays)) {
         days = dayOrDays;
       } else if (dayOrDays instanceof Object && dayOrDays.date instanceof Date) {
         days = [dayOrDays];
@@ -55,7 +56,7 @@ export default CalendarComponent.extend({
   _buildCollection(days) {
     let selected = this.get("publicAPI.selected") || [];
 
-    for (const day of days) {
+    for (let day of days) {
       let index = selected.findIndex(selectedDate => isSame(day.date, selectedDate, "day"));
       if (index === -1) {
         selected = [...selected, day.date];

--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -10,6 +10,7 @@ import {
   isBefore,
   normalizeDuration
 } from 'ember-power-calendar-utils';
+import { assert } from '@ember/debug';
 
 export default CalendarComponent.extend({
   daysComponent: 'power-calendar-range/days',
@@ -66,8 +67,19 @@ export default CalendarComponent.extend({
 
   // Actions
   actions: {
-    select(day, calendar, e) {
-      let range = this._buildRange(day);
+    select({ date }, calendar, e) {
+      assert(
+        'date must be either a Date, or a Range', 
+        date && (date.hasOwnProperty('start') || date.hasOwnProperty('end') || date instanceof Date)
+      );
+
+      let range;
+      if (date && (date.hasOwnProperty('start') || date.hasOwnProperty('end'))) {
+        range = { date };
+      } else {
+        range = this._buildRange({ date });
+      }
+
       let { start, end } = range.date;
       if (start && end) {
         let { minRange, maxRange } = this.get('publicAPI');
@@ -76,6 +88,7 @@ export default CalendarComponent.extend({
           return;
         }
       }
+
       let action = this.get('onSelect');
       if (action) {
         action(range, calendar, e);

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -101,7 +101,6 @@ module('Integration | Component | power calendar range', function(hooks) {
     assert.expect(4);
     this.rangeToSelect = { date: { start: undefined, end: undefined } };
     this.selected = { date: { start: new Date(2013, 9, 5), end: new Date(2013, 9, 10) } };
-
     this.didChange = range => {
       assert.ok(
         range && range.date && range.date.hasOwnProperty('start') && range.date.hasOwnProperty('end'),
@@ -123,7 +122,6 @@ module('Integration | Component | power calendar range', function(hooks) {
 
     this.set('rangeToSelect', { date: { start: new Date(2013, 9, 15), end: new Date(2013, 9, 20) } });
     this.set('selected', { date: { start: new Date(2013, 9, 5), end: new Date(2013, 9, 10) } });
-
     this.set('didChange', range => {
       assert.ok(
         range && range.date && range.date.hasOwnProperty('start') && range.date.hasOwnProperty('end'),


### PR DESCRIPTION
Passing `calendar.actions.select({ start, end })` to the range select action will now skip the range selection logic and directly pass the range to the user provided handler.