### PR TITLE
Add ember-concurrency 1.0 to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ember-cli-babel": "^7.2.0",
     "ember-cli-element-closest-polyfill": "^0.0.1",
     "ember-cli-htmlbars": "^3.0.1",
-    "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0"
+    "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
ember-concurrency@1.0 was just released and there are no breaking changes.