### PR TITLE
Vanilla CSS support for basic calendar styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,19 @@
 * `cd my-addon`
 * `npm install`
 
+## Styling changes
+
+Whenever changes are made to a `.less` or `.scss` file,
+the changes need to be made in both of these files,
+and we need to apply the changes to the CSS file as well.
+Run the following command to update the CSS found in `vendor`:
+
+```sh
+yarn run compile-css
+```
+
+Do not make changes by hand to `ember-power-calendar.css`. 
+
 ## Linting
 
 * `npm run lint:hbs`

--- a/app/styles/ember-power-calendar.scss
+++ b/app/styles/ember-power-calendar.scss
@@ -224,3 +224,18 @@
     color: $day-other-month-text-color--hover;
   }
 }
+
+// These defaults are used for generating CSS-only styles.
+// See compile-css.js
+
+.ember-power-calendar-default-small {
+  @include ember-power-calendar($cell-size: 30px);
+}
+
+.ember-power-calendar-default-medium {
+  @include ember-power-calendar($cell-size: 50px);
+}
+
+.ember-power-calendar-default-large {
+  @include ember-power-calendar($cell-size: 70px);
+}

--- a/compile-css.js
+++ b/compile-css.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 /*
 This turns SCSS into CSS that can be used in projects that don't use a
 precompiler.
@@ -13,7 +15,7 @@ var buf = fs.readFileSync(inputFile, "utf8");
 
 var result = sass.renderSync({
   data: buf,
-  includePaths: ['app/styles/ember-power-calendar-defaults.scss']
+  includePaths: ['app/styles/ember-power-calendar.scss']
 });
 
 fs.writeFileSync(outputFile, result.css);

--- a/compile-css.js
+++ b/compile-css.js
@@ -1,0 +1,19 @@
+/*
+This turns SCSS into CSS that can be used in projects that don't use a
+precompiler.
+*/
+
+var sass = require('sass'); // eslint-disable-line
+var fs = require('fs');
+var path = require('path');
+
+var inputFile = path.join(__dirname, 'app', 'styles', 'ember-power-calendar.scss');
+var outputFile = path.join(__dirname, 'vendor', 'ember-power-calendar.css');
+var buf = fs.readFileSync(inputFile, "utf8");
+
+var result = sass.renderSync({
+  data: buf,
+  includePaths: ['app/styles/ember-power-calendar-defaults.scss']
+});
+
+fs.writeFileSync(outputFile, result.css);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "test": "ember test",
-    "test:all": "ember try:each"
+    "test:all": "ember try:each",
+    "compile-css": "node compile-css.js"
   },
   "engines": {
     "node": "8.* || >= 10.*"
@@ -18,7 +19,8 @@
     "app/",
     "addon-test-support/",
     "test-support/",
-    "index.js"
+    "index.js",
+    "vendor/"
   ],
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/tests/dummy/app/templates/public-pages/docs/installation.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/installation.hbs
@@ -49,8 +49,10 @@
 <h3>Add the styles</h3>
 
 <p>
-  This addon still requires Sass or Less, although support for people using vanilla CSS is coming.
+  This addon supports styling with Sass, Less, and CSS.
 </p>
+
+<h4>Sass</h4>
 
 <p>
   If you are using Sass, all you need to do is import the addon styles with:
@@ -74,6 +76,8 @@
 {{code-snippet name="installation-2a.scss" classNames="code-sample-snippet" class="active"}}
 <br>
 
+<h4>Less</h4>
+
 <p>
   For those using Less, the process is very similar. Import the addon styles with:
 </p>
@@ -88,6 +92,38 @@
 
 <p>
   This code above will make each one of those classes have a different size.
+</p>
+
+<h4>CSS</h4>
+
+<p>
+  While it is recommended to use Sass or Less in order to take advantage of themeing features,
+  some default styles are available in plain CSS as well.
+</p>
+
+<p>
+  Import the addon styles with:
+</p>
+{{code-snippet name="installation-4.less" classNames="code-sample-snippet" class="active"}}
+<br>
+
+<p>
+  Apply one of these classes to your component:
+  <code>.ember-power-calendar-default-small</code> for a cell size of 30px,
+  <code>.ember-power-calendar-default-medium</code> for 50px, or
+  <code>.ember-power-calendar-default-large</code> for 70px:
+</p>
+{{code-snippet name="installation-5.less" classNames="code-sample-snippet" class="active"}}
+<br>
+
+<p>
+  If you are using CSS and want to apply your own styling, you can
+  override the default rules provided following regular
+  <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank" rel="noopener noreferrer">
+    CSS specificity.
+  </a>
+  Developers who want to make major changes to styling are encouraged
+  to use Sass or Less instead, since Mixins make this much easier.
 </p>
 
 <div class="doc-page-nav">

--- a/tests/dummy/app/templates/public-pages/docs/installation.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/installation.hbs
@@ -104,16 +104,22 @@
 <p>
   Import the addon styles with:
 </p>
-{{code-snippet name="installation-4.less" classNames="code-sample-snippet" class="active"}}
+{{code-snippet name="installation-5.css" classNames="code-sample-snippet" class="active"}}
 <br>
 
 <p>
-  Apply one of these classes to your component:
-  <code>.ember-power-calendar-default-small</code> for a cell size of 30px,
-  <code>.ember-power-calendar-default-medium</code> for 50px, or
-  <code>.ember-power-calendar-default-large</code> for 70px:
+  Apply one of these classes to your component, depending on the cell size that you want to use:
+  <ul>
+    <li><code>.ember-power-calendar-default-small</code> for 30px</li>
+    <li><code>.ember-power-calendar-default-medium</code> for 50px</li>
+    <li><code>.ember-power-calendar-default-large</code> for 70px</li>
+  </ul>
 </p>
-{{code-snippet name="installation-5.less" classNames="code-sample-snippet" class="active"}}
+
+<p>
+  For example:
+</p>
+{{code-snippet name="installation-6.hbs" classNames="code-sample-snippet" class="active"}}
 <br>
 
 <p>

--- a/tests/dummy/app/templates/snippets/installation-5.css
+++ b/tests/dummy/app/templates/snippets/installation-5.css
@@ -1,0 +1,1 @@
+@import "ember-power-calendar";

--- a/tests/dummy/app/templates/snippets/installation-6.hbs
+++ b/tests/dummy/app/templates/snippets/installation-6.hbs
@@ -1,0 +1,3 @@
+<PowerCalendar class="ember-power-calendar-default-small" as |calendar|>
+  <calendar.Days />
+</PowerCalendar>

--- a/vendor/ember-power-calendar.css
+++ b/vendor/ember-power-calendar.css
@@ -1,0 +1,393 @@
+.ember-power-calendar {
+  box-sizing: border-box;
+  position: relative;
+}
+
+.ember-power-calendar-nav {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+}
+
+.ember-power-calendar-nav * {
+  box-sizing: border-box;
+}
+
+.ember-power-calendar-days, .ember-power-calendar-days * {
+  box-sizing: border-box;
+}
+
+.ember-power-calendar-nav-title {
+  flex: 1;
+  text-align: center;
+}
+
+.ember-power-calendar-row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.ember-power-calendar-weekday {
+  -webkit-appearance: none;
+  flex: 1 1 100%;
+  padding: 0;
+  background-color: transparent;
+  background-color: initial;
+  border: none;
+  border: initial;
+  outline: none;
+  outline: initial;
+  justify-content: center;
+  display: flex;
+  align-items: center;
+  padding: 0;
+}
+
+.ember-power-calendar-day {
+  -webkit-appearance: none;
+  background-color: transparent;
+  background-color: initial;
+  border: none;
+  border: initial;
+  outline: none;
+  outline: initial;
+  flex: 1 1 100%;
+  font-size: inherit;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.ember-power-calendar-nav-control {
+  -webkit-appearance: none;
+  background-color: transparent;
+  background-color: initial;
+  border: none;
+  border: initial;
+  outline: none;
+  outline: initial;
+  font-size: inherit;
+}
+
+.ember-power-calendar {
+  font-size: 14px;
+  line-height: 1.42857;
+}
+
+.ember-power-calendar-nav {
+  line-height: 2;
+}
+
+.ember-power-calendar-nav-control {
+  line-height: 1;
+  font-size: 150%;
+}
+.ember-power-calendar-nav-control:focus {
+  transform: scale(1.2);
+}
+
+.ember-power-calendar-day--selected,
+.ember-power-calendar-day--selected:not([disabled]):hover {
+  font-weight: bold;
+}
+
+.ember-power-calendar-day--interactive[disabled] {
+  opacity: 0.4;
+}
+
+.ember-power-calendar-default-small {
+  width: 222px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:first-child[data-missing-days="1"] {
+  padding-left: 32px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:first-child[data-missing-days="2"] {
+  padding-left: 64px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:first-child[data-missing-days="3"] {
+  padding-left: 96px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:first-child[data-missing-days="4"] {
+  padding-left: 128px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:first-child[data-missing-days="5"] {
+  padding-left: 160px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:first-child[data-missing-days="6"] {
+  padding-left: 192px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:last-child[data-missing-days="1"] {
+  padding-right: 32px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:last-child[data-missing-days="2"] {
+  padding-right: 64px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:last-child[data-missing-days="3"] {
+  padding-right: 96px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:last-child[data-missing-days="4"] {
+  padding-right: 128px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:last-child[data-missing-days="5"] {
+  padding-right: 160px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-week:last-child[data-missing-days="6"] {
+  padding-right: 192px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day, .ember-power-calendar-default-small .ember-power-calendar-weekday {
+  max-width: 30px;
+  max-height: 30px;
+  width: 30px;
+  height: 30px;
+}
+.ember-power-calendar-default-small .ember-power-calendar-weekdays, .ember-power-calendar-default-small .ember-power-calendar-week {
+  height: 32px;
+  padding-left: 0;
+  padding-right: 0;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day {
+  color: #bbb;
+}
+.ember-power-calendar-default-small .ember-power-calendar-weekdays {
+  color: #333333;
+}
+.ember-power-calendar-default-small .ember-power-calendar-nav-control {
+  color: #0078c9;
+}
+.ember-power-calendar-default-small .ember-power-calendar-nav-control:focus {
+  color: #30acff;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--current-month {
+  color: #656D78;
+  background-color: #F5F7FA;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--today {
+  background-color: #eee;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day:not([disabled]):hover {
+  background-color: #eee;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--focused {
+  box-shadow: inset 0px -2px 0px 0px #0078c9;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--selected.ember-power-calendar-day--range-start {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--selected.ember-power-calendar-day--range-start:hover {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--selected.ember-power-calendar-day--range-end {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--selected.ember-power-calendar-day--range-end:hover {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--selected {
+  background-color: #c9e9ff;
+  color: #656D78;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--selected:not([disabled]):hover {
+  background-color: #c9e9ff;
+  color: #656D78;
+}
+.ember-power-calendar-default-small .ember-power-calendar-day--other-month:not([disabled]):hover {
+  color: #656D78;
+}
+
+.ember-power-calendar-default-medium {
+  width: 362px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:first-child[data-missing-days="1"] {
+  padding-left: 52px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:first-child[data-missing-days="2"] {
+  padding-left: 104px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:first-child[data-missing-days="3"] {
+  padding-left: 156px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:first-child[data-missing-days="4"] {
+  padding-left: 208px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:first-child[data-missing-days="5"] {
+  padding-left: 260px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:first-child[data-missing-days="6"] {
+  padding-left: 312px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:last-child[data-missing-days="1"] {
+  padding-right: 52px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:last-child[data-missing-days="2"] {
+  padding-right: 104px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:last-child[data-missing-days="3"] {
+  padding-right: 156px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:last-child[data-missing-days="4"] {
+  padding-right: 208px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:last-child[data-missing-days="5"] {
+  padding-right: 260px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-week:last-child[data-missing-days="6"] {
+  padding-right: 312px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day, .ember-power-calendar-default-medium .ember-power-calendar-weekday {
+  max-width: 50px;
+  max-height: 50px;
+  width: 50px;
+  height: 50px;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-weekdays, .ember-power-calendar-default-medium .ember-power-calendar-week {
+  height: 52px;
+  padding-left: 0;
+  padding-right: 0;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day {
+  color: #bbb;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-weekdays {
+  color: #333333;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-nav-control {
+  color: #0078c9;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-nav-control:focus {
+  color: #30acff;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--current-month {
+  color: #656D78;
+  background-color: #F5F7FA;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--today {
+  background-color: #eee;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day:not([disabled]):hover {
+  background-color: #eee;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--focused {
+  box-shadow: inset 0px -2px 0px 0px #0078c9;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--selected.ember-power-calendar-day--range-start {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--selected.ember-power-calendar-day--range-start:hover {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--selected.ember-power-calendar-day--range-end {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--selected.ember-power-calendar-day--range-end:hover {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--selected {
+  background-color: #c9e9ff;
+  color: #656D78;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--selected:not([disabled]):hover {
+  background-color: #c9e9ff;
+  color: #656D78;
+}
+.ember-power-calendar-default-medium .ember-power-calendar-day--other-month:not([disabled]):hover {
+  color: #656D78;
+}
+
+.ember-power-calendar-default-large {
+  width: 502px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:first-child[data-missing-days="1"] {
+  padding-left: 72px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:first-child[data-missing-days="2"] {
+  padding-left: 144px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:first-child[data-missing-days="3"] {
+  padding-left: 216px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:first-child[data-missing-days="4"] {
+  padding-left: 288px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:first-child[data-missing-days="5"] {
+  padding-left: 360px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:first-child[data-missing-days="6"] {
+  padding-left: 432px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:last-child[data-missing-days="1"] {
+  padding-right: 72px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:last-child[data-missing-days="2"] {
+  padding-right: 144px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:last-child[data-missing-days="3"] {
+  padding-right: 216px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:last-child[data-missing-days="4"] {
+  padding-right: 288px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:last-child[data-missing-days="5"] {
+  padding-right: 360px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-week:last-child[data-missing-days="6"] {
+  padding-right: 432px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day, .ember-power-calendar-default-large .ember-power-calendar-weekday {
+  max-width: 70px;
+  max-height: 70px;
+  width: 70px;
+  height: 70px;
+}
+.ember-power-calendar-default-large .ember-power-calendar-weekdays, .ember-power-calendar-default-large .ember-power-calendar-week {
+  height: 72px;
+  padding-left: 0;
+  padding-right: 0;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day {
+  color: #bbb;
+}
+.ember-power-calendar-default-large .ember-power-calendar-weekdays {
+  color: #333333;
+}
+.ember-power-calendar-default-large .ember-power-calendar-nav-control {
+  color: #0078c9;
+}
+.ember-power-calendar-default-large .ember-power-calendar-nav-control:focus {
+  color: #30acff;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--current-month {
+  color: #656D78;
+  background-color: #F5F7FA;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--today {
+  background-color: #eee;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day:not([disabled]):hover {
+  background-color: #eee;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--focused {
+  box-shadow: inset 0px -2px 0px 0px #0078c9;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--selected.ember-power-calendar-day--range-start {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--selected.ember-power-calendar-day--range-start:hover {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--selected.ember-power-calendar-day--range-end {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--selected.ember-power-calendar-day--range-end:hover {
+  background-color: #96d5ff;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--selected {
+  background-color: #c9e9ff;
+  color: #656D78;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--selected:not([disabled]):hover {
+  background-color: #c9e9ff;
+  color: #656D78;
+}
+.ember-power-calendar-default-large .ember-power-calendar-day--other-month:not([disabled]):hover {
+  color: #656D78;
+}


### PR DESCRIPTION
This PR adds:

- invoking the mixins at the bottom of the main `.scss` file
- a script to generate css based on the scss file, and a command for it in package.json. This is based on the script in ember-power-select
- the resulting generated css to the vendor folder, the same as is done in ember-power-select
- updates to the documentation
- a section to the Contributing readme that says how to generate the css
- adding `vendor` to the `files` array in package.json, so it is included on publish (I think? Does anything else need to be done for that?) 

It is marked as a draft because I am not able to run this (or master, or any recent tags) locally using yarn link. Any ideas why? I get the following error in the browser console:

```
Error: Assertion Failed: The @layout decorator must be provided a template, received: owner => {
      var result = cache.get(owner);

      if (result === undefined) {
        counters.cacheMiss++;
        var compiler = owner.lookup(TEMPLATE_COMPILER_MAIN);
        result = glimmerFactory.create(compiler, {
          owner
        });
        cache.set(owner, result);
      } else {
        counters.cacheHit++;
      }

      return result;
    }
```