### PR TITLE
Added optional @tag argument to <PowerCalendar />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+## 0.14.4
+- [ENHANCEMENT] Added support for optional `@tag` argument to `<PowerCalendar />`
 
 ## 0.14.3
 - [BUGFIX] Remove deprecation by adding a setter for the locale to power-calendar service.

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -88,6 +88,14 @@ export default @layout(templateLayout) @tagName('') class extends Component {
     };
   }
 
+  @computed('tag')
+  get tagWithDefault() {
+    if (this.tag === undefined || this.tag === null) {
+      return 'div';
+    }
+    return this.tag;
+  }
+
   // Actions
   @action
   select(day, calendar, e) {

--- a/addon/templates/components/power-calendar.hbs
+++ b/addon/templates/components/power-calendar.hbs
@@ -2,12 +2,14 @@
   Nav=(component this.navComponent calendar=(readonly this.publicAPI))
   Days=(component this.daysComponent calendar=(readonly this.publicAPI))
 )) as |calendar|}}
-  <div class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
-    {{#if hasBlock}}
-      {{yield calendar}}
-    {{else}}
-      <calendar.Nav/>
-      <calendar.Days/>
-    {{/if}}
-  </div>
+  {{#let (element (or @tagName "div")) as |Tag|}}
+    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
+      {{#if hasBlock}}
+        {{yield calendar}}
+      {{else}}
+        <calendar.Nav/>
+        <calendar.Days/>
+      {{/if}}
+    </Tag>
+  {{/let}}
 {{/with}}

--- a/addon/templates/components/power-calendar.hbs
+++ b/addon/templates/components/power-calendar.hbs
@@ -2,7 +2,7 @@
   Nav=(component this.navComponent calendar=(readonly this.publicAPI))
   Days=(component this.daysComponent calendar=(readonly this.publicAPI))
 )) as |calendar|}}
-  {{#let (element (or @tagName "div")) as |Tag|}}
+  {{#let (element this.tagWithDefault) as |Tag|}}
     <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
       {{#if hasBlock}}
         {{yield calendar}}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ember-cli-element-closest-polyfill": "^0.0.1",
     "ember-cli-htmlbars": "^3.1.0",
     "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0 || ^1.1.0",
+    "ember-element-helper": "^0.2.0",
     "ember-truth-helpers": "^2.1.0"
   },
   "ember-addon": {

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -676,4 +676,12 @@ module('Integration | Component | <PowerCalendar>', function(hooks) {
     assert.dom('.ember-power-calendar-day[data-date="2013-10-15"]').hasClass('ember-power-calendar-day--focused');
     assert.equal(document.activeElement, this.element.querySelector('.ember-power-calendar-day[data-date="2013-10-15"]'));
   });
+
+  test('user can provide `@tagName` attribute', async function(assert) {
+    assert.expect(1);
+    await render(hbs`
+      <PowerCalendar @tagName="li" />
+    `);
+    assert.dom('li.ember-power-calendar').exists('default `div` overwritten with `li`');
+  });
 });

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -677,11 +677,19 @@ module('Integration | Component | <PowerCalendar>', function(hooks) {
     assert.equal(document.activeElement, this.element.querySelector('.ember-power-calendar-day[data-date="2013-10-15"]'));
   });
 
-  test('user can provide `@tagName` attribute', async function(assert) {
-    assert.expect(1);
-    await render(hbs`
-      <PowerCalendar @tagName="li" />
-    `);
-    assert.dom('li.ember-power-calendar').exists('default `div` overwritten with `li`');
-  });
+  test('user can provide `@tag` attribute', async function(assert) { 
+    assert.expect(1); 
+    await render(hbs` 
+      <PowerCalendar @tag="li" /> 
+    `); 
+    assert.dom('li.ember-power-calendar').exists('default `div` overwritten with `li`'); 
+  }); 
+ 
+  test('user can provide empty `@tag` attribute', async function(assert) { 
+    assert.expect(1); 
+    await render(hbs` 
+      <PowerCalendar @tag="" /> 
+    `); 
+    assert.dom('.ember-power-calendar').doesNotExist('default `div` overwritten'); 
+  }); 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,6 +4106,13 @@ ember-element-helper@^0.1.1:
   dependencies:
     ember-cli-babel "^6.16.0"
 
+ember-element-helper@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.2.0.tgz#eacdf4d8507d6708812623206e24ad37bad487e7"
+  integrity sha512-/WV0PNLyxDvLX/YETb/8KICFTr719OYqFWXqV5XUkh9YhhBGDU/mr1OtlQaWOlsx+sHm42HD2UAICecqex8ziw==
+  dependencies:
+    ember-cli-babel "^6.16.0"
+
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"


### PR DESCRIPTION
Before the library the library updated to octane #221 users could overwrite the `{{power-calendar}}`'s outer `div` by passing `tagName` to the component as an argument.

This PR restores that behavior with an optional `@tag` argument.