### PR TITLE
Widen `ember-truth-helpers` dependency constraint to allow v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0 || ^1.1.0",
     "ember-decorators": "^6.1.1",
     "ember-element-helper": "^0.2.0",
-    "ember-truth-helpers": "^2.1.0"
+    "ember-truth-helpers": "^2.1.0 || ^3.0.0"
   },
   "ember": {
     "edition": "octane"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6415,7 +6415,7 @@ ember-text-measurer@^0.6.0:
     ember-cli-babel "^7.19.0"
     ember-cli-htmlbars "^4.3.1"
 
-ember-truth-helpers@2.1.0, ember-truth-helpers@^2.0.0, ember-truth-helpers@^2.1.0:
+ember-truth-helpers@2.1.0, ember-truth-helpers@^2.0.0, ember-truth-helpers@^2.1.0, "ember-truth-helpers@^2.1.0 || ^3.0.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz#d4dab4eee7945aa2388126485977baeb33ca0798"
   integrity sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==


### PR DESCRIPTION
Similar to https://github.com/cibernox/ember-basic-dropdown/pull/584