### PR TITLE
fix: resolve `hasBlock` usage deprecation

### DIFF
--- a/addon/templates/components/power-calendar.hbs
+++ b/addon/templates/components/power-calendar.hbs
@@ -4,7 +4,7 @@
 )) as |calendar|}}
   {{#let (element this.tagWithDefault) as |Tag|}}
     <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
-      {{#if hasBlock}}
+      {{#if (has-block)}}
         {{yield calendar}}
       {{else}}
         <calendar.Nav/>

--- a/addon/templates/components/power-calendar/days.hbs
+++ b/addon/templates/components/power-calendar/days.hbs
@@ -19,7 +19,7 @@
             {{on "focus" this.handleDayFocus}}
             {{on "blur" this.handleDayBlur}}
             disabled={{day.isDisabled}}>
-            {{#if hasBlock}}
+            {{#if (has-block)}}
               {{yield day @calendar this.weeks}}
             {{else}}
               {{day.number}}

--- a/addon/templates/components/power-calendar/nav.hbs
+++ b/addon/templates/components/power-calendar/nav.hbs
@@ -3,7 +3,7 @@
     <button type="button" class="ember-power-calendar-nav-control ember-power-calendar-nav-control--previous" {{on "click" (fn calendar.actions.moveCenter -1 this.unit @calendar)}}>«</button>
   {{/if}}
   <div class="ember-power-calendar-nav-title">
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       {{yield @calendar}}
     {{else}}
       {{power-calendar-format-date @calendar.center this.format locale=@calendar.locale}}


### PR DESCRIPTION
As of Ember 3.26, using `hasBlock` is deprecated. The non-deprecated version is to invoke `has-block` as a helper without params, so that's what I've migrated to!

It seems like `has-block` was introduced in Ember 3.10, so with 3.13 being the earliest version that this addon is tested against, it should be safe to release as a non-breaking change 🎉