### PR TITLE
Use let instead of with

### DIFF
--- a/addon/templates/components/power-calendar.hbs
+++ b/addon/templates/components/power-calendar.hbs
@@ -1,4 +1,4 @@
-{{#with (assign this.publicAPI (hash
+{{#let (assign this.publicAPI (hash
   Nav=(component this.navComponent calendar=(readonly this.publicAPI))
   Days=(component this.daysComponent calendar=(readonly this.publicAPI))
 )) as |calendar|}}
@@ -12,4 +12,4 @@
       {{/if}}
     </Tag>
   {{/let}}
-{{/with}}
+{{/let}}

--- a/tests/dummy/app/templates/snippets/nav-select-1.hbs
+++ b/tests/dummy/app/templates/snippets/nav-select-1.hbs
@@ -4,24 +4,24 @@
 
   <calendar.Nav>
     <span class="with-invisible-select">
-      {{#with (format-date calendar.center 'MMMM') as |currentMonth|}}
+      {{#let (format-date calendar.center 'MMMM') as |currentMonth|}}
         {{currentMonth}}
         <select onchange={{fn this.changeCenter "month" calendar}}>
           {{#each months as |month|}}
             <option value="{{month}}" selected={{eq month currentMonth}}>{{month}}</option>
           {{/each}}
         </select>
-      {{/with}}
+      {{/let}}
     </span>
     <span class="with-invisible-select">
-      {{#with (format-date calendar.center 'YYYY') as |currentYear|}}
+      {{#let (format-date calendar.center 'YYYY') as |currentYear|}}
         {{currentYear}}
         <select onchange={{fn this.changeCenter "year" calendar}}>
           {{#each years as |year|}}
             <option value="{{year}}" selected={{eq year currentYear}}>{{year}}</option>
           {{/each}}
         </select>
-      {{/with}}
+      {{/let}}
     </span>
   </calendar.Nav>
 

--- a/tests/dummy/app/templates/snippets/the-days-1.hbs
+++ b/tests/dummy/app/templates/snippets/the-days-1.hbs
@@ -2,12 +2,12 @@
   <calendar.Nav/>
 
   <calendar.Days as |day|>
-    {{#with (format-date day.date 'ddd') as |weekday|}}
+    {{#let (format-date day.date 'ddd') as |weekday|}}
       {{#if (or (eq weekday "Sat") (eq weekday "Sun"))}}
         <strong class="pink-text">{{day.number}}</strong>
       {{else}}
         {{day.number}}
       {{/if}}
-    {{/with}}
+    {{/let}}
   </calendar.Days>
 </PowerCalendar>


### PR DESCRIPTION
The `with` helper is deprecated. We should use `let` instead.