### PR TITLE
Fix embroider-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Ember Power Calendar [![Build Status](https://travis-ci.org/cibernox/ember-power-calendar.svg?branch=master)](https://travis-ci.org/cibernox/ember-power-calendar)
+# Ember Power Calendar
+
+[![CI](https://github.com/cibernox/ember-power-calendar/actions/workflows/ci.yml/badge.svg)](https://github.com/cibernox/ember-power-calendar/actions/workflows/ci.yml)
+[![Ember Observer Score](http://emberobserver.com/badges/ember-power-calendar.svg)](http://emberobserver.com/addons/ember-power-calendar)
+[![Code Climate](https://codeclimate.com/github/cibernox/ember-power-calendar/badges/gpa.svg)](https://codeclimate.com/github/cibernox/ember-power-calendar)
+[![npm version](https://badge.fury.io/js/ember-power-calendar.svg)](https://badge.fury.io/js/ember-power-calendar)
 
 Customizable Calendar Component for Ember.
 
-## Disclaimer
+## Compatibility
 
-Version 0.14 of this addon requires Ember 3.11 or greater.
-Versions below 0.14 would work with Ember 3.0+ (and perhaps 2.12+)
+* Ember.js v3.28 or above
+* Ember CLI v3.28 or above
+* Node.js v16 or above
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/cibernox/ember-power-calendar/actions/workflows/ci.yml/badge.svg)](https://github.com/cibernox/ember-power-calendar/actions/workflows/ci.yml)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-power-calendar.svg)](http://emberobserver.com/addons/ember-power-calendar)
-[![Code Climate](https://codeclimate.com/github/cibernox/ember-power-calendar/badges/gpa.svg)](https://codeclimate.com/github/cibernox/ember-power-calendar)
 [![npm version](https://badge.fury.io/js/ember-power-calendar.svg)](https://badge.fury.io/js/ember-power-calendar)
 
 Customizable Calendar Component for Ember.

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import { assert } from '@ember/debug';
 import { click, settled, find } from '@ember/test-helpers';
-import { formatDate } from 'ember-power-calendar-utils';
+import { formatDate } from 'ember-power-calendar/utils';
 
 function findCalendarElement(selector) {
   let target = find(selector);

--- a/addon/components/power-calendar-multiple.js
+++ b/addon/components/power-calendar-multiple.js
@@ -5,7 +5,7 @@ import {
   normalizeDate,
   isSame,
   normalizeMultipleActionValue,
-} from 'ember-power-calendar-utils';
+} from 'ember-power-calendar/utils';
 import { assert } from '@ember/debug';
 import { isArray } from '@ember/array';
 import PowerCalendarMultipleDaysComponent from './power-calendar-multiple/days';

--- a/addon/components/power-calendar-multiple/days.js
+++ b/addon/components/power-calendar-multiple/days.js
@@ -1,5 +1,5 @@
 import DaysComponent from '../power-calendar/days';
-import { isSame } from 'ember-power-calendar-utils';
+import { isSame } from 'ember-power-calendar/utils';
 
 export default class extends DaysComponent {
   get maxLength() {

--- a/addon/components/power-calendar-range.js
+++ b/addon/components/power-calendar-range.js
@@ -8,7 +8,7 @@ import {
   isAfter,
   isBefore,
   normalizeDuration,
-} from 'ember-power-calendar-utils';
+} from 'ember-power-calendar/utils';
 import { assert } from '@ember/debug';
 
 import ownProp from 'ember-power-calendar/-private/utils/own-prop';

--- a/addon/components/power-calendar-range/days.js
+++ b/addon/components/power-calendar-range/days.js
@@ -1,5 +1,5 @@
 import DaysComponent from '../power-calendar/days';
-import { isBetween, isSame, diff } from 'ember-power-calendar-utils';
+import { isBetween, isSame, diff } from 'ember-power-calendar/utils';
 
 export default class extends DaysComponent {
   // Methods

--- a/addon/components/power-calendar.js
+++ b/addon/components/power-calendar.js
@@ -9,7 +9,7 @@ import {
   add,
   normalizeDate,
   normalizeCalendarValue,
-} from 'ember-power-calendar-utils';
+} from 'ember-power-calendar/utils';
 import PowerCalendarNavComponent from './power-calendar/nav';
 import PowerCalendarDaysComponent from './power-calendar/days';
 

--- a/addon/components/power-calendar/days.js
+++ b/addon/components/power-calendar/days.js
@@ -21,7 +21,7 @@ import {
   startOf,
   startOfWeek,
   withLocale,
-} from 'ember-power-calendar-utils';
+} from 'ember-power-calendar/utils';
 
 const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 

--- a/addon/helpers/power-calendar-format-date.js
+++ b/addon/helpers/power-calendar-format-date.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { formatDate } from 'ember-power-calendar-utils';
+import { formatDate } from 'ember-power-calendar/utils';
 
 export function powerCalendarFormatDate([date, format], { locale }) {
   return formatDate(date, format, locale);

--- a/addon/services/power-calendar.js
+++ b/addon/services/power-calendar.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { getDefaultLocale } from 'ember-power-calendar-utils';
+import { getDefaultLocale } from 'ember-power-calendar/utils';
 
 export default class extends Service {
   date = null;

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -74,8 +74,8 @@ export function diff(date1, date2) {
   return DateLibrary.diff(date1, date2);
 }
 
-export function normalizeDate(dateOrMoment) {
-  return DateLibrary.normalizeDate(dateOrMoment);
+export function normalizeDate(date) {
+  return DateLibrary.normalizeDate(date);
 }
 
 export function normalizeRangeActionValue(val) {

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,0 +1,119 @@
+import {
+  dependencySatisfies,
+  macroCondition,
+  importSync,
+} from '@embroider/macros';
+
+const DateLibrary = (() => {
+  if (macroCondition(dependencySatisfies('ember-power-calendar-moment', '*'))) {
+    return importSync('ember-power-calendar-moment');
+  } else if (
+    macroCondition(dependencySatisfies('ember-power-calendar-luxon', '*'))
+  ) {
+    return importSync('ember-power-calendar-luxon');
+  } else {
+    throw new Error(
+      `You have installed "ember-power-calendar" but you don't have any of the required meta-addons to make it work, like 'ember-power-calendar-moment' or 'ember-power-calendar-luxon'. Please add to your app.`,
+    );
+  }
+})();
+
+export function add(date, quantity, unit) {
+  return DateLibrary.add(date, quantity, unit);
+}
+
+export function formatDate(date, format, locale = null) {
+  return DateLibrary.formatDate(date, format, locale);
+}
+
+export function startOf(date, unit) {
+  return DateLibrary.startOf(date, unit);
+}
+
+export function endOf(date, unit) {
+  return DateLibrary.endOf(date, unit);
+}
+
+export function weekday(date) {
+  return DateLibrary.weekday(date);
+}
+
+export function isoWeekday(date) {
+  return DateLibrary.isoWeekday(date);
+}
+
+export function getWeekdaysShort() {
+  return DateLibrary.getWeekdaysShort();
+}
+
+export function getWeekdaysMin() {
+  return DateLibrary.getWeekdaysMin();
+}
+
+export function getWeekdays() {
+  return DateLibrary.getWeekdays();
+}
+
+export function isAfter(date1, date2) {
+  return DateLibrary.isAfter(date1, date2);
+}
+
+export function isBefore(date1, date2) {
+  return DateLibrary.isBefore(date1, date2);
+}
+
+export function isSame(date1, date2, unit) {
+  return DateLibrary.isSame(date1, date2, unit);
+}
+
+export function isBetween(date, start, end, unit, inclusivity) {
+  return DateLibrary.isBetween(date, start, end, unit, inclusivity);
+}
+
+export function diff(date1, date2) {
+  return DateLibrary.diff(date1, date2);
+}
+
+export function normalizeDate(dateOrMoment) {
+  return DateLibrary.normalizeDate(dateOrMoment);
+}
+
+export function normalizeRangeActionValue(val) {
+  return DateLibrary.normalizeRangeActionValue(val);
+}
+
+export function normalizeMultipleActionValue(val) {
+  return DateLibrary.normalizeMultipleActionValue(val);
+}
+
+export function normalizeCalendarDay(day) {
+  return DateLibrary.normalizeCalendarDay(day);
+}
+
+export function withLocale(locale, fn) {
+  return DateLibrary.withLocale(locale, fn);
+}
+
+export function normalizeCalendarValue(value) {
+  return DateLibrary.normalizeCalendarValue(value);
+}
+
+export function normalizeDuration(value) {
+  return DateLibrary.normalizeDuration(value);
+}
+
+export function getDefaultLocale() {
+  return DateLibrary.getDefaultLocale();
+}
+
+export function localeStartOfWeek(locale) {
+  return DateLibrary.localeStartOfWeek(locale);
+}
+
+export function startOfWeek(day, startOfWeek) {
+  return DateLibrary.startOfWeek(day, startOfWeek);
+}
+
+export function endOfWeek(day, startOfWeek) {
+  return DateLibrary.endOfWeek(day, startOfWeek);
+}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,7 +18,6 @@ module.exports = function (defaults) {
   */
 
   const { maybeEmbroider } = require('@embroider/test-setup');
-  const webpack = require('webpack');
 
   return maybeEmbroider(app, {
     skipBabel: [
@@ -26,15 +25,5 @@ module.exports = function (defaults) {
         package: 'qunit',
       },
     ],
-    packagerOptions: {
-      webpackConfig: {
-        plugins: [
-          new webpack.IgnorePlugin({
-            // workaround for https://github.com/embroider-build/ember-auto-import/issues/578
-            resourceRegExp: /moment/,
-          }),
-        ],
-      },
-    },
   });
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,11 +18,23 @@ module.exports = function (defaults) {
   */
 
   const { maybeEmbroider } = require('@embroider/test-setup');
+  const webpack = require('webpack');
+
   return maybeEmbroider(app, {
     skipBabel: [
       {
         package: 'qunit',
       },
     ],
+    packagerOptions: {
+      webpackConfig: {
+        plugins: [
+          new webpack.IgnorePlugin({
+            // workaround for https://github.com/embroider-build/ember-auto-import/issues/578
+            resourceRegExp: /moment/,
+          }),
+        ],
+      },
+    },
   });
 };

--- a/index.js
+++ b/index.js
@@ -2,43 +2,4 @@
 
 module.exports = {
   name: require('./package').name,
-
-  included() {
-    this._super.included.apply(this, arguments);
-    if (
-      ['ember-power-calendar-moment', 'ember-power-calendar-luxon'].includes(
-        this.project.name(),
-      )
-    ) {
-      return;
-    }
-
-    const hostAppAddons = this.project.addonPackages;
-    const parentAddons = this.parent.addonPackages;
-
-    const hasMetaAddon = (addons) => {
-      for (let addonName in addons) {
-        if (
-          addons[addonName].pkg.keywords.indexOf(
-            'ember-power-calendar-adapter',
-          ) > -1
-        ) {
-          return true;
-        }
-      }
-      // The above check works for ember-power-calendar-moment 0.1.7+ and for
-      // ember-power-calendar-luxon 0.1.8+, but in case someone has an older version I keep this
-      // whitelist.
-      return (
-        Object.hasOwnProperty.call(addons, 'ember-power-calendar-moment') ||
-        Object.hasOwnProperty.call(addons, 'ember-power-calendar-luxon')
-      );
-    };
-
-    if (!hasMetaAddon(hostAppAddons) && !hasMetaAddon(parentAddons)) {
-      throw new Error(
-        `You have installed "ember-power-calendar" but you don't have any of the required meta-addons to make it work, like 'ember-power-calendar-moment' or 'ember-power-calendar-luxon'`,
-      );
-    }
-  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ember-data": "~4.12.0",
         "ember-load-initializers": "^2.1.2",
         "ember-page-title": "^7.0.0",
-        "ember-power-calendar-moment": "^0.2.0",
+        "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
         "ember-power-select": "^7.1.0",
         "ember-qunit": "^7.0.0",
         "ember-resolver": "^11.0.0",
@@ -33215,7 +33215,7 @@
       "version": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
       "integrity": "sha512-LFNx99c4AZ8KlPwqCHalpHWDLmYmkwen09daWokOAKyokRk85tSchqFopz5oDVazWQNDDfWPxuWVURVKLjL75Q==",
       "dev": true,
-      "from": "ember-power-calendar-moment@^0.2.0",
+      "from": "ember-power-calendar-moment@git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
       "requires": {
         "broccoli-funnel": "^2.0.2",
         "ember-auto-import": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
+        "@ember/render-modifiers": "^2.1.0",
         "@embroider/macros": "^1.13.1",
         "ember-assign-helper": "^0.4.0",
         "ember-auto-import": "^2.6.3",
@@ -41,7 +42,7 @@
         "ember-data": "~4.12.0",
         "ember-load-initializers": "^2.1.2",
         "ember-page-title": "^7.0.0",
-        "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
+        "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
         "ember-power-select": "^7.1.0",
         "ember-qunit": "^7.0.0",
         "ember-resolver": "^11.0.0",
@@ -75,7 +76,7 @@
       },
       "peerDependencies": {
         "ember-power-calendar-luxon": "^0.4.0",
-        "ember-power-calendar-moment": "^0.2.0",
+        "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
         "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
       },
       "peerDependenciesMeta": {
@@ -2533,7 +2534,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-2.1.0.tgz",
       "integrity": "sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==",
-      "dev": true,
       "dependencies": {
         "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.11",
@@ -11599,7 +11599,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
       "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
-      "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.10.0",
         "ember-cli-version-checker": "^2.1.2",
@@ -11613,7 +11612,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
       "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
       "dependencies": {
         "resolve": "^1.3.3",
         "semver": "^5.3.0"
@@ -11626,7 +11624,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -11692,22 +11689,23 @@
     },
     "node_modules/ember-power-calendar-moment": {
       "version": "0.2.0",
-      "resolved": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
-      "integrity": "sha512-LFNx99c4AZ8KlPwqCHalpHWDLmYmkwen09daWokOAKyokRk85tSchqFopz5oDVazWQNDDfWPxuWVURVKLjL75Q==",
+      "resolved": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
+      "integrity": "sha512-JAESAFwyngfst+jzUx53IDZKlOCr5RVS/2e9EIBA5p61oz5wXG38CMcoKJkCSx0PTCE9Te5jouGsccRnv5B3oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "broccoli-funnel": "^2.0.2",
-        "ember-auto-import": "^2.4.0",
-        "ember-cli-babel": "^7.26.10",
-        "ember-cli-htmlbars": "^5.7.2"
+        "@embroider/macros": "^1.13.1",
+        "ember-auto-import": "^2.6.3",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.2.0"
       },
       "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": "16.* || >= 18"
       },
       "peerDependencies": {
-        "moment": "^2",
-        "moment-timezone": "^0.5.34"
+        "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
+        "moment": "^2.0.0",
+        "moment-timezone": "^0.5.43"
       },
       "peerDependenciesMeta": {
         "moment": {
@@ -11717,440 +11715,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/async-disk-cache/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/async-disk-cache/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/async-disk-cache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/broccoli-persistent-filter/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/editions/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ember-cli-htmlbars/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ember-cli-htmlbars/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ember-cli-htmlbars/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ember-cli-htmlbars/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ember-cli-htmlbars/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/sync-disk-cache/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/sync-disk-cache/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/sync-disk-cache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-power-calendar-moment/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/ember-power-select": {
       "version": "7.1.0",
@@ -25935,7 +25499,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-2.1.0.tgz",
       "integrity": "sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==",
-      "dev": true,
       "requires": {
         "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.11",
@@ -33177,7 +32740,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
       "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.10.0",
         "ember-cli-version-checker": "^2.1.2",
@@ -33188,7 +32750,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -33197,8 +32758,7 @@
         "semver": {
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -33212,354 +32772,15 @@
       }
     },
     "ember-power-calendar-moment": {
-      "version": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
-      "integrity": "sha512-LFNx99c4AZ8KlPwqCHalpHWDLmYmkwen09daWokOAKyokRk85tSchqFopz5oDVazWQNDDfWPxuWVURVKLjL75Q==",
+      "version": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
+      "integrity": "sha512-JAESAFwyngfst+jzUx53IDZKlOCr5RVS/2e9EIBA5p61oz5wXG38CMcoKJkCSx0PTCE9Te5jouGsccRnv5B3oA==",
       "dev": true,
-      "from": "ember-power-calendar-moment@git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
+      "from": "ember-power-calendar-moment@git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
       "requires": {
-        "broccoli-funnel": "^2.0.2",
-        "ember-auto-import": "^2.4.0",
-        "ember-cli-babel": "^7.26.10",
-        "ember-cli-htmlbars": "^5.7.2"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.3.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-              "dev": true,
-              "requires": {
-                "ms": "2.1.2"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            },
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          },
-          "dependencies": {
-            "broccoli-plugin": {
-              "version": "4.0.7",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-              "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-              "dev": true,
-              "requires": {
-                "broccoli-node-api": "^1.7.0",
-                "broccoli-output-wrapper": "^3.2.5",
-                "fs-merger": "^3.2.1",
-                "promise-map-series": "^0.3.0",
-                "quick-temp": "^0.1.8",
-                "rimraf": "^3.0.2",
-                "symlink-or-copy": "^1.3.1"
-              },
-              "dependencies": {
-                "promise-map-series": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-                  "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-                  "dev": true
-                }
-              }
-            },
-            "fs-tree-diff": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-              "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-              "dev": true,
-              "requires": {
-                "@types/symlink-or-copy": "^1.2.0",
-                "heimdalljs-logger": "^0.1.7",
-                "object-assign": "^4.1.0",
-                "path-posix": "^1.0.0",
-                "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          },
-          "dependencies": {
-            "broccoli-plugin": {
-              "version": "4.0.7",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-              "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-              "dev": true,
-              "requires": {
-                "broccoli-node-api": "^1.7.0",
-                "broccoli-output-wrapper": "^3.2.5",
-                "fs-merger": "^3.2.1",
-                "promise-map-series": "^0.3.0",
-                "quick-temp": "^0.1.8",
-                "rimraf": "^3.0.2",
-                "symlink-or-copy": "^1.3.1"
-              }
-            },
-            "fs-tree-diff": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-              "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-              "dev": true,
-              "requires": {
-                "@types/symlink-or-copy": "^1.2.0",
-                "heimdalljs-logger": "^0.1.7",
-                "object-assign": "^4.1.0",
-                "path-posix": "^1.0.0",
-                "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "promise-map-series": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-              "dev": true
-            },
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "walk-sync": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-              "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-              "dev": true,
-              "requires": {
-                "@types/minimatch": "^3.0.3",
-                "ensure-posix-path": "^1.1.0",
-                "matcher-collection": "^2.0.0",
-                "minimatch": "^3.0.4"
-              }
-            }
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.3.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-              "dev": true,
-              "requires": {
-                "ms": "2.1.2"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            },
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
+        "@embroider/macros": "^1.13.1",
+        "ember-auto-import": "^2.6.3",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.2.0"
       }
     },
     "ember-power-select": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "ember-basic-dropdown": "^7.2.1",
         "ember-cli": "~4.12.0",
         "ember-cli-app-version": "^6.0.1",
-        "ember-cli-custom-assertions": "^0.3.0",
         "ember-cli-dependency-checker": "^3.3.2",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-sass": "^11.0.1",
@@ -2868,9 +2867,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2889,9 +2888,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2912,9 +2911,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2939,9 +2938,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3200,31 +3199,21 @@
       }
     },
     "node_modules/@lint-todo/utils": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.0.tgz",
-      "integrity": "sha512-uzcZPIPH7hcs+hKMiHfp58MosJpI9sTTgl1pGYau4zq34q1ppswJ6nLeohv/cDhqEBrHjtvldt8zDnVJXRvBlA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.1.tgz",
+      "integrity": "sha512-F5z53uvRIF4dYfFfJP3a2Cqg+4P1dgJchJsFnsZE0eZp0LK8X7g2J0CsJHRgns+skpXOlM7n5vFGwkWCWj8qJg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint": "^7.2.13",
+        "@types/eslint": "^8.4.9",
         "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
         "proper-lockfile": "^4.1.2",
         "slash": "^3.0.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "upath": "^2.0.1"
       },
       "engines": {
         "node": "12.* || >= 14"
-      }
-    },
-    "node_modules/@lint-todo/utils/node_modules/@types/eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -3481,9 +3470,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
-      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ=="
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -5681,9 +5670,9 @@
       }
     },
     "node_modules/broccoli-sass-source-maps": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.1.0.tgz",
-      "integrity": "sha512-So3gTlP9AEJTponlRoL9Ti+xaMX1LnJUWD52mVT0Oq6PI8nIjX97XMW91JfY/4CXsprIDyGe/7rkiauE+XHdPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.2.0.tgz",
+      "integrity": "sha512-TXCfhGAojbp2ZND9gsmUV9DyWb1yb6LUaurvT+blQITCT5LXQSx2Bs2Hbq3JxwhAvrZ7IJcDMoPRL8zajaRoBQ==",
       "dev": true,
       "dependencies": {
         "broccoli-caching-writer": "^3.0.3",
@@ -6711,9 +6700,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001519",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+      "version": "1.0.30001521",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
+      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8385,9 +8374,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.488",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.488.tgz",
-      "integrity": "sha512-Dv4sTjiW7t/UWGL+H8ZkgIjtUAVZDgb/PwGWvMsCT7jipzUV/u5skbLXPFKb6iV0tiddVi/bcS2/kUrczeWgIQ=="
+      "version": "1.4.494",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.494.tgz",
+      "integrity": "sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww=="
     },
     "node_modules/ember-assign-helper": {
       "version": "0.4.0",
@@ -9254,19 +9243,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/ember-cli-custom-assertions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-custom-assertions/-/ember-cli-custom-assertions-0.3.0.tgz",
-      "integrity": "sha512-XfuGoGaAYJbNu8SkL8oByp9HGsUC7lJS+5imkuDaqjPBsfHyVKF7mh2emV/N1MzeUnFjgU8hNlgPb1gruFhySQ==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-string-utils": "^1.1.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-cli-dependency-checker": {
@@ -12356,9 +12332,9 @@
       }
     },
     "node_modules/ember-resolver": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-11.0.0.tgz",
-      "integrity": "sha512-TOc685OnGEMMNEt04BukmQHOYVXnRJc+sGZij/vzWdxXRq+Wpsu1Nw2nLFo6fbMqqVLATk5oLKAQ1eKQwte2wQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-11.0.1.tgz",
+      "integrity": "sha512-ucBk3oM+PR+AfYoSUXeQh8cDQS1sSiEKp4Pcgbew5cFMSqPxJfqd1zyZsfQKNTuyubeGmWxBOyMVSTvX2LeCyg==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.11"
@@ -12716,12 +12692,12 @@
       "dev": true
     },
     "node_modules/ember-template-lint": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-5.11.1.tgz",
-      "integrity": "sha512-PucOG+Wx96h8NNjgD4kTjBzg6qTGOCqvo3agubuHJ3/T9ucO0P88FzEPxWRPWgn4b/PqIyDXj8HhkM7QUccBIQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-5.11.2.tgz",
+      "integrity": "sha512-G8KXmFCYLKM9ifMb+rluL8CNIawUl45i4z4VrK+Nn5ciWSo+Vx2jUp+sS6wKCdBqGYoiqjUgn/hmGnCVOId+yQ==",
       "dev": true,
       "dependencies": {
-        "@lint-todo/utils": "^13.0.3",
+        "@lint-todo/utils": "^13.1.1",
         "aria-query": "^5.3.0",
         "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
@@ -13962,15 +13938,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.1",
-        "@eslint/js": "^8.46.0",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "^8.47.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -13981,7 +13957,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.2",
+        "eslint-visitor-keys": "^3.4.3",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -14316,9 +14292,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -14328,9 +14304,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -14402,9 +14378,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -15069,9 +15045,9 @@
       }
     },
     "node_modules/filesize": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.9.tgz",
-      "integrity": "sha512-BzSxJtyq7ZEBjQPEC6u7GNrK58xwaITCvHPaH7e5145eowrMwLfm5LMu/7PeHTTKxP4joIyNmxCbVJVXv7xPGQ==",
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.12.tgz",
+      "integrity": "sha512-6RS9gDchbn+qWmtV2uSjo5vmKizgfCQeb5jKmqx8HyzA3MoLqqyQxN+QcjkGBJt7FjJ9qFce67Auyya5rRRbpw==",
       "dev": true,
       "engines": {
         "node": ">= 10.4.0"
@@ -17414,12 +17390,15 @@
       "dev": true
     },
     "node_modules/language-tags": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.8.tgz",
-      "integrity": "sha512-aWAZwgPLS8hJ20lNPm9HNVs4inexz6S2sQa3wx/+ycuutMNE5/IfYxiWYBbi+9UWCQVaXYCOPUl6gFrPR7+jGg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "dependencies": {
         "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/lcid": {
@@ -19374,18 +19353,18 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-      "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -19646,9 +19625,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
       "funding": [
         {
           "type": "opencollective",
@@ -19756,9 +19735,9 @@
       }
     },
     "node_modules/postcss-scss": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
-      "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.7.tgz",
+      "integrity": "sha512-xPv2GseoyXPa58Nro7M73ZntttusuCmZdeOojUFR5PZDz2BR62vfYx1w9TyOnp1+nYFowgOMipsCBhxzVkAEPw==",
       "dev": true,
       "funding": [
         {
@@ -19768,6 +19747,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "engines": {
@@ -19813,9 +19796,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -20953,9 +20936,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.64.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
-      "integrity": "sha512-TnDlfc+CRnUAgLO9D8cQLFu/GIjJIzJCGkE7o4ekIGQOH7T3GetiRR/PsTWJUHhkzcSPrARkPI+gNWn5alCzDg==",
+      "version": "1.65.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.65.1.tgz",
+      "integrity": "sha512-9DINwtHmA41SEd36eVPQ9BJKpn7eKDQmUHmpI0y5Zv2Rcorrh0zS+cFrt050hdNbmmCNKTW3hV5mWfuegNRsEA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -23780,9 +23763,9 @@
       }
     },
     "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
+      "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -26169,9 +26152,9 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-          "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
           "dev": true
         }
       }
@@ -26183,9 +26166,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -26200,9 +26183,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.20.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -26217,9 +26200,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
       "dev": true
     },
     "@glimmer/component": {
@@ -26453,30 +26436,18 @@
       }
     },
     "@lint-todo/utils": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.0.tgz",
-      "integrity": "sha512-uzcZPIPH7hcs+hKMiHfp58MosJpI9sTTgl1pGYau4zq34q1ppswJ6nLeohv/cDhqEBrHjtvldt8zDnVJXRvBlA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.1.tgz",
+      "integrity": "sha512-F5z53uvRIF4dYfFfJP3a2Cqg+4P1dgJchJsFnsZE0eZp0LK8X7g2J0CsJHRgns+skpXOlM7n5vFGwkWCWj8qJg==",
       "dev": true,
       "requires": {
-        "@types/eslint": "^7.2.13",
+        "@types/eslint": "^8.4.9",
         "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
         "proper-lockfile": "^4.1.2",
         "slash": "^3.0.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "upath": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/eslint": {
-          "version": "7.29.0",
-          "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-          "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*",
-            "@types/json-schema": "*"
-          }
-        }
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -26713,9 +26684,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.4.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
-      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ=="
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -28820,9 +28791,9 @@
       }
     },
     "broccoli-sass-source-maps": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.1.0.tgz",
-      "integrity": "sha512-So3gTlP9AEJTponlRoL9Ti+xaMX1LnJUWD52mVT0Oq6PI8nIjX97XMW91JfY/4CXsprIDyGe/7rkiauE+XHdPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.2.0.tgz",
+      "integrity": "sha512-TXCfhGAojbp2ZND9gsmUV9DyWb1yb6LUaurvT+blQITCT5LXQSx2Bs2Hbq3JxwhAvrZ7IJcDMoPRL8zajaRoBQ==",
       "dev": true,
       "requires": {
         "broccoli-caching-writer": "^3.0.3",
@@ -29339,9 +29310,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001519",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg=="
+      "version": "1.0.30001521",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
+      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -30574,9 +30545,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.488",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.488.tgz",
-      "integrity": "sha512-Dv4sTjiW7t/UWGL+H8ZkgIjtUAVZDgb/PwGWvMsCT7jipzUV/u5skbLXPFKb6iV0tiddVi/bcS2/kUrczeWgIQ=="
+      "version": "1.4.494",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.494.tgz",
+      "integrity": "sha512-KF7wtsFFDu4ws1ZsSOt4pdmO1yWVNWCFtijVYZPUeW4SV7/hy/AESjLn/+qIWgq7mHscNOKAwN5AIM1+YAy+Ww=="
     },
     "ember-assign-helper": {
       "version": "0.4.0",
@@ -31654,16 +31625,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz",
       "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw=="
-    },
-    "ember-cli-custom-assertions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-custom-assertions/-/ember-cli-custom-assertions-0.3.0.tgz",
-      "integrity": "sha512-XfuGoGaAYJbNu8SkL8oByp9HGsUC7lJS+5imkuDaqjPBsfHyVKF7mh2emV/N1MzeUnFjgU8hNlgPb1gruFhySQ==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-string-utils": "^1.1.0"
-      }
     },
     "ember-cli-dependency-checker": {
       "version": "3.3.2",
@@ -33736,9 +33697,9 @@
       }
     },
     "ember-resolver": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-11.0.0.tgz",
-      "integrity": "sha512-TOc685OnGEMMNEt04BukmQHOYVXnRJc+sGZij/vzWdxXRq+Wpsu1Nw2nLFo6fbMqqVLATk5oLKAQ1eKQwte2wQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-11.0.1.tgz",
+      "integrity": "sha512-ucBk3oM+PR+AfYoSUXeQh8cDQS1sSiEKp4Pcgbew5cFMSqPxJfqd1zyZsfQKNTuyubeGmWxBOyMVSTvX2LeCyg==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.11"
@@ -33999,12 +33960,12 @@
       }
     },
     "ember-template-lint": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-5.11.1.tgz",
-      "integrity": "sha512-PucOG+Wx96h8NNjgD4kTjBzg6qTGOCqvo3agubuHJ3/T9ucO0P88FzEPxWRPWgn4b/PqIyDXj8HhkM7QUccBIQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-5.11.2.tgz",
+      "integrity": "sha512-G8KXmFCYLKM9ifMb+rluL8CNIawUl45i4z4VrK+Nn5ciWSo+Vx2jUp+sS6wKCdBqGYoiqjUgn/hmGnCVOId+yQ==",
       "dev": true,
       "requires": {
-        "@lint-todo/utils": "^13.0.3",
+        "@lint-todo/utils": "^13.1.1",
         "aria-query": "^5.3.0",
         "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
@@ -34958,15 +34919,15 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.1",
-        "@eslint/js": "^8.46.0",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "^8.47.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -34977,7 +34938,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.2",
+        "eslint-visitor-keys": "^3.4.3",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -35053,15 +35014,15 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-          "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
           "dev": true
         },
         "globals": {
-          "version": "13.20.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -35256,9 +35217,9 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-          "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
           "dev": true
         }
       }
@@ -35790,9 +35751,9 @@
       }
     },
     "filesize": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.9.tgz",
-      "integrity": "sha512-BzSxJtyq7ZEBjQPEC6u7GNrK58xwaITCvHPaH7e5145eowrMwLfm5LMu/7PeHTTKxP4joIyNmxCbVJVXv7xPGQ==",
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.12.tgz",
+      "integrity": "sha512-6RS9gDchbn+qWmtV2uSjo5vmKizgfCQeb5jKmqx8HyzA3MoLqqyQxN+QcjkGBJt7FjJ9qFce67Auyya5rRRbpw==",
       "dev": true
     },
     "fill-range": {
@@ -37543,9 +37504,9 @@
       "dev": true
     },
     "language-tags": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.8.tgz",
-      "integrity": "sha512-aWAZwgPLS8hJ20lNPm9HNVs4inexz6S2sQa3wx/+ycuutMNE5/IfYxiWYBbi+9UWCQVaXYCOPUl6gFrPR7+jGg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "requires": {
         "language-subtag-registry": "^0.3.20"
@@ -39082,15 +39043,15 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
           "dev": true
         },
         "minipass": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-          "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
           "dev": true
         }
       }
@@ -39284,9 +39245,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -39345,9 +39306,9 @@
       "requires": {}
     },
     "postcss-scss": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
-      "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.7.tgz",
+      "integrity": "sha512-xPv2GseoyXPa58Nro7M73ZntttusuCmZdeOojUFR5PZDz2BR62vfYx1w9TyOnp1+nYFowgOMipsCBhxzVkAEPw==",
       "dev": true,
       "requires": {}
     },
@@ -39378,9 +39339,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -40225,9 +40186,9 @@
       }
     },
     "sass": {
-      "version": "1.64.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
-      "integrity": "sha512-TnDlfc+CRnUAgLO9D8cQLFu/GIjJIzJCGkE7o4ekIGQOH7T3GetiRR/PsTWJUHhkzcSPrARkPI+gNWn5alCzDg==",
+      "version": "1.65.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.65.1.tgz",
+      "integrity": "sha512-9DINwtHmA41SEd36eVPQ9BJKpn7eKDQmUHmpI0y5Zv2Rcorrh0zS+cFrt050hdNbmmCNKTW3hV5mWfuegNRsEA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -42426,9 +42387,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
+      "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
+        "@embroider/macros": "^1.13.1",
         "ember-assign-helper": "^0.4.0",
         "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
@@ -73,7 +74,17 @@
         "node": "16.* || >= 18"
       },
       "peerDependencies": {
+        "ember-power-calendar-luxon": "^0.4.0",
+        "ember-power-calendar-moment": "^0.2.0",
         "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ember-power-calendar-luxon": {
+          "optional": true
+        },
+        "ember-power-calendar-moment": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -11681,9 +11692,10 @@
     },
     "node_modules/ember-power-calendar-moment": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ember-power-calendar-moment/-/ember-power-calendar-moment-0.2.0.tgz",
-      "integrity": "sha512-8CL2o4KScrNOhmVAgoFEgdDy3K0k8+4DjRHeXcX6PstxOj9/ZDU+/ST2XUrDRBDSLfzaf3WIhr3siPPwh0LY9A==",
+      "resolved": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
+      "integrity": "sha512-LFNx99c4AZ8KlPwqCHalpHWDLmYmkwen09daWokOAKyokRk85tSchqFopz5oDVazWQNDDfWPxuWVURVKLjL75Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "broccoli-funnel": "^2.0.2",
         "ember-auto-import": "^2.4.0",
@@ -33200,10 +33212,10 @@
       }
     },
     "ember-power-calendar-moment": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ember-power-calendar-moment/-/ember-power-calendar-moment-0.2.0.tgz",
-      "integrity": "sha512-8CL2o4KScrNOhmVAgoFEgdDy3K0k8+4DjRHeXcX6PstxOj9/ZDU+/ST2XUrDRBDSLfzaf3WIhr3siPPwh0LY9A==",
+      "version": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
+      "integrity": "sha512-LFNx99c4AZ8KlPwqCHalpHWDLmYmkwen09daWokOAKyokRk85tSchqFopz5oDVazWQNDDfWPxuWVURVKLjL75Q==",
       "dev": true,
+      "from": "ember-power-calendar-moment@^0.2.0",
       "requires": {
         "broccoli-funnel": "^2.0.2",
         "ember-auto-import": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
-    "ember-power-calendar-moment": "^0.2.0",
+    "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
     "ember-power-calendar-luxon": "^0.4.0"
   },
   "peerDependenciesMeta": {
@@ -65,7 +65,7 @@
     "ember-data": "~4.12.0",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
-    "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
+    "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#9497cf4ff7d9cf94f74d9c091daca3f04eaaf4d6",
     "ember-power-select": "^7.1.0",
     "ember-qunit": "^7.0.0",
     "ember-resolver": "^11.0.0",
@@ -111,6 +111,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^2.1.0",
     "@embroider/macros": "^1.13.1",
     "ember-assign-helper": "^0.4.0",
     "ember-auto-import": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ember-basic-dropdown": "^7.2.1",
     "ember-cli": "~4.12.0",
     "ember-cli-app-version": "^6.0.1",
-    "ember-cli-custom-assertions": "^0.3.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,17 @@
     "test:ember-compatibility": "ember try:each"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
+    "ember-power-calendar-moment": "^0.2.0",
+    "ember-power-calendar-luxon": "^0.4.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-power-calendar-moment": {
+      "optional": true
+    },
+    "ember-power-calendar-luxon": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "16.* || >= 18"
@@ -101,6 +111,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@embroider/macros": "^1.13.1",
     "ember-assign-helper": "^0.4.0",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ember-data": "~4.12.0",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
-    "ember-power-calendar-moment": "^0.2.0",
+    "ember-power-calendar-moment": "git+https://git@github.com/mkszepp/ember-power-calendar-moment.git#7ec4d6e573f1a90c40287882f1c934cffcc58696",
     "ember-power-select": "^7.1.0",
     "ember-qunit": "^7.0.0",
     "ember-resolver": "^11.0.0",

--- a/test-app/node_modules/.package-lock.json
+++ b/test-app/node_modules/.package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/test-app/node_modules/.package-lock.json
+++ b/test-app/node_modules/.package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "test-app",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "test-app",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/tests/assertions/is-calendar.js
+++ b/tests/assertions/is-calendar.js
@@ -1,6 +1,6 @@
 import ownProp from 'ember-power-calendar/-private/utils/own-prop';
 
-export default function isCalendar(_context, calendar, message) {
+export default function isCalendar(calendar, message) {
   let result =
     !!calendar &&
     ownProp(calendar, 'center') &&

--- a/tests/assertions/is-day.js
+++ b/tests/assertions/is-day.js
@@ -1,4 +1,4 @@
-export default function isDay(context, day, message = 'Is a valid day object') {
+export default function isDay(day, message = 'Is a valid day object') {
   let result =
     typeof day.isCurrentMonth === 'boolean' &&
     typeof day.isToday === 'boolean' &&

--- a/tests/dummy/app/components/days-grid-without-mon-or-wed.js
+++ b/tests/dummy/app/components/days-grid-without-mon-or-wed.js
@@ -5,7 +5,7 @@ import {
   startOf,
   endOf,
   weekday,
-} from 'ember-power-calendar-utils';
+} from 'ember-power-calendar/utils';
 
 export default class extends Component {
   get days() {

--- a/tests/dummy/app/components/snippets/multiple-months-1.js
+++ b/tests/dummy/app/components/snippets/multiple-months-1.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { add } from 'ember-power-calendar-utils';
+import { add } from 'ember-power-calendar/utils';
 
 export default class extends Component {
   @tracked center = new Date('2016-05-17');

--- a/tests/dummy/app/components/snippets/the-days-2.js
+++ b/tests/dummy/app/components/snippets/the-days-2.js
@@ -5,7 +5,7 @@ import {
   startOf,
   endOf,
   weekday,
-} from 'ember-power-calendar-utils';
+} from 'ember-power-calendar/utils';
 
 export default class extends Component {
   get days() {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { add } from 'ember-power-calendar-utils';
+import { add } from 'ember-power-calendar/utils';
 
 export default class extends Controller {
   tomorrow = add(new Date(), 1, 'day');

--- a/tests/dummy/app/controllers/public-pages.js
+++ b/tests/dummy/app/controllers/public-pages.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { add } from 'ember-power-calendar-utils';
+import { add } from 'ember-power-calendar/utils';
 import { task, timeout, waitForQueue } from 'ember-concurrency';
 
 export default class extends Controller {

--- a/tests/dummy/app/helpers/format-date.js
+++ b/tests/dummy/app/helpers/format-date.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { formatDate } from 'ember-power-calendar-utils';
+import { formatDate } from 'ember-power-calendar/utils';
 
 export function formatDateHelper([date, format], { locale }) {
   return formatDate(date, format, locale);

--- a/tests/dummy/app/initializers/global-locale.js
+++ b/tests/dummy/app/initializers/global-locale.js
@@ -1,11 +1,12 @@
 import require from 'require';
+import { importSync } from '@embroider/macros';
 
 const dateLibrary = require.has('luxon') ? 'luxon' : 'moment';
 
 export default {
   initialize() {
     if (dateLibrary === 'moment') {
-      let moment = require('moment').default;
+      let moment = importSync('moment');
       moment.locale('en');
     }
   },

--- a/tests/dummy/app/initializers/global-locale.js
+++ b/tests/dummy/app/initializers/global-locale.js
@@ -6,7 +6,7 @@ const dateLibrary = require.has('luxon') ? 'luxon' : 'moment';
 export default {
   initialize() {
     if (dateLibrary === 'moment') {
-      let moment = importSync('moment');
+      let moment = importSync('moment').default;
       moment.locale('en');
     }
   },

--- a/tests/integration/components/power-calendar-multiple-test.js
+++ b/tests/integration/components/power-calendar-multiple-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
-import { isSame, formatDate } from 'ember-power-calendar-utils';
+import { isSame, formatDate } from 'ember-power-calendar/utils';
 
 module('Integration | Component | <PowerCalendarMultiple>', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/power-calendar-multiple-test.js
+++ b/tests/integration/components/power-calendar-multiple-test.js
@@ -5,11 +5,9 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { isSame, formatDate } from 'ember-power-calendar-utils';
-import setupCustomAssertions from 'ember-cli-custom-assertions/test-support';
 
 module('Integration | Component | <PowerCalendarMultiple>', function (hooks) {
   setupRenderingTest(hooks);
-  setupCustomAssertions(hooks);
 
   hooks.beforeEach(function () {
     let calendarService = this.owner.lookup('service:power-calendar');

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
-import { isSame } from 'ember-power-calendar-utils';
+import { isSame } from 'ember-power-calendar/utils';
 
 import ownProp from 'ember-power-calendar/-private/utils/own-prop';
 

--- a/tests/integration/components/power-calendar-range-test.js
+++ b/tests/integration/components/power-calendar-range-test.js
@@ -5,13 +5,11 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { isSame } from 'ember-power-calendar-utils';
-import setupCustomAssertions from 'ember-cli-custom-assertions/test-support';
 
 import ownProp from 'ember-power-calendar/-private/utils/own-prop';
 
 module('Integration | Component | <PowerCalendarRange>', function (hooks) {
   setupRenderingTest(hooks);
-  setupCustomAssertions(hooks);
 
   hooks.beforeEach(function () {
     let calendarService = this.owner.lookup('service:power-calendar');

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { run, later } from '@ember/runloop';
 import RSVP from 'rsvp';
 import require from 'require';
+import { importSync } from '@embroider/macros';
 
 import ownProp from 'ember-power-calendar/-private/utils/own-prop';
 
@@ -120,7 +121,7 @@ module('Integration | Component | <PowerCalendar>', function (hooks) {
   });
 
   if (dateLibrary === 'moment') {
-    let moment = require('moment').default;
+    let moment = importSync('moment');
     test('when it receives a `moment()` in the `center` argument, it displays that month', async function (assert) {
       assert.expect(3);
       this.center = moment('2016-02-05');
@@ -200,7 +201,7 @@ module('Integration | Component | <PowerCalendar>', function (hooks) {
         );
     });
   } else if (dateLibrary === 'luxon') {
-    let { DateTime } = require('luxon');
+    let { DateTime } = importSync('luxon');
     test('when it receives a DateTime in the `center` argument, it displays that month', async function (assert) {
       assert.expect(3);
       this.center = DateTime.fromObject({ year: 2016, month: 2, day: 5 });

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -121,7 +121,7 @@ module('Integration | Component | <PowerCalendar>', function (hooks) {
   });
 
   if (dateLibrary === 'moment') {
-    let moment = importSync('moment');
+    let moment = importSync('moment').default;
     test('when it receives a `moment()` in the `center` argument, it displays that month', async function (assert) {
       assert.expect(3);
       this.center = moment('2016-02-05');

--- a/tests/integration/components/power-calendar-test.js
+++ b/tests/integration/components/power-calendar-test.js
@@ -5,7 +5,6 @@ import hbs from 'htmlbars-inline-precompile';
 import { run, later } from '@ember/runloop';
 import RSVP from 'rsvp';
 import require from 'require';
-import setupCustomAssertions from 'ember-cli-custom-assertions/test-support';
 
 import ownProp from 'ember-power-calendar/-private/utils/own-prop';
 
@@ -13,7 +12,6 @@ const dateLibrary = require.has('luxon') ? 'luxon' : 'moment';
 
 module('Integration | Component | <PowerCalendar>', function (hooks) {
   setupRenderingTest(hooks);
-  setupCustomAssertions(hooks);
 
   hooks.beforeEach(function () {
     let calendarService = this.owner.lookup('service:power-calendar');

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,8 +4,13 @@ import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
+import isCalendar from './assertions/is-calendar';
+import isDay from './assertions/is-day';
 
 setApplication(Application.create(config.APP));
+
+QUnit.assert.isCalendar = isCalendar;
+QUnit.assert.isDay = isDay;
 
 setup(QUnit.assert);
 

--- a/tests/unit/utils/date-utils-test.js
+++ b/tests/unit/utils/date-utils-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { add } from 'ember-power-calendar-utils';
+import { add } from 'ember-power-calendar/utils';
 
 module('Unit | Utility | date-utils', function () {
   module('#add', function () {


### PR DESCRIPTION
- Add helper for date library, which is handling the import from `ember-power-calendar-moment` & `ember-power-calendar-luxon` (replaced package-name `ember-power-calendar-utils` doesn't anymore)
- fix embroider-safe / embroider-optimized

We need to release `ember-power-calendar-moment` & `ember-power-calendar-luxon` before we can release