### PR TITLE
Add option to use `ember-power-calendar.scss`

### DIFF
--- a/ember-power-calendar/_index.scss
+++ b/ember-power-calendar/_index.scss
@@ -1,1 +1,1 @@
-@import './scss/base.scss';
+@import './ember-power-calendar.scss';

--- a/ember-power-calendar/ember-power-calendar.scss
+++ b/ember-power-calendar/ember-power-calendar.scss
@@ -1,0 +1,1 @@
+@import './scss/base.scss';

--- a/ember-power-calendar/package.json
+++ b/ember-power-calendar/package.json
@@ -16,6 +16,7 @@
     "./*": "./dist/*.js",
     "./addon-main.js": "./addon-main.cjs",
     "./ember-power-calendar.less": "./ember-power-calendar.less",
+    "./ember-power-calendar.scss": "./ember-power-calendar.scss",
     "./_index.scss": "./_index.scss",
     "./less/base.less": "./less/base.less",
     "./scss/base.scss": "./scss/base.scss",
@@ -27,6 +28,7 @@
     "declarations",
     "dist",
     "ember-power-calendar.less",
+    "ember-power-calendar.scss",
     "less",
     "scss",
     "vendor"


### PR DESCRIPTION
Add option for consumer apps to use import `@import 'ember-power-calendar.scss'`

this works with `ember-cli-scss` only by adding `scssOptions`
```js
let app = new EmberApp(defaults, {
    ...
    sassOptions: {
      includePaths: ['node_modules/ember-power-calendar'],
    },
    ...
  });
```

This was maybe working in older versions (without adding the setting `sassOptions`), but was not documented