### PR TITLE
chore: handle ambiguous instances of helpers

### DIFF
--- a/ember-power-calendar/src/components/power-calendar/days.hbs
+++ b/ember-power-calendar/src/components/power-calendar/days.hbs
@@ -3,7 +3,7 @@
   class="ember-power-calendar-days"
   {{on "click" this.handleClick}}
   ...attributes
-  data-power-calendar-id={{or @calendar.calendarUniqueId @calendar.uniqueId}}>
+  data-power-calendar-id={{(or @calendar.calendarUniqueId @calendar.uniqueId)}}>
   <div class="ember-power-calendar-row ember-power-calendar-weekdays">
     {{#each this.weekdaysNames as |wdn|}}
       <div class="ember-power-calendar-weekday">{{wdn}}</div>
@@ -15,7 +15,7 @@
         {{#each week.days key='id' as |day|}}
           <button type="button"
             data-date="{{day.id}}"
-            class={{ember-power-calendar-day-classes day @calendar this.weeks @dayClass}}
+            class={{(ember-power-calendar-day-classes day @calendar this.weeks @dayClass)}}
             {{on "focus" this.handleDayFocus}}
             {{on "blur" this.handleDayBlur}}
             disabled={{day.isDisabled}}>

--- a/ember-power-calendar/src/components/power-calendar/nav.hbs
+++ b/ember-power-calendar/src/components/power-calendar/nav.hbs
@@ -6,7 +6,7 @@
     {{#if (has-block)}}
       {{yield @calendar}}
     {{else}}
-      {{power-calendar-format-date @calendar.center this.format locale=@calendar.locale}}
+      {{(power-calendar-format-date @calendar.center this.format locale=@calendar.locale)}}
     {{/if}}
   </div>
   {{#if @calendar.actions.changeCenter}}


### PR DESCRIPTION
This is needed to turn on `staticHelpers` embroider flag.