### PR TITLE
Use datelibrary to compare months

### DIFF
--- a/ember-power-calendar/src/-private/days-utils.ts
+++ b/ember-power-calendar/src/-private/days-utils.ts
@@ -188,7 +188,7 @@ export function buildDay(
     date: new Date(date),
     isDisabled: isDisabled,
     isFocused: focusedId === id,
-    isCurrentMonth: date.getMonth() === currentCenter.getMonth(),
+    isCurrentMonth: isSame(date, currentCenter, 'month'),
     isToday: isSame(date, today, 'day'),
     isSelected: dayIsSelected(date, calendar),
   } as PowerCalendarDay);


### PR DESCRIPTION
Nowadays we rely on JavaScript dates when checking whether or not a day belongs to the same month. Which leads us to a problem, because depending on the timezone configured, we can jump or be behind by a day.

However, when using [momentjs.com/timezone/](https://momentjs.com/timezone/), it is necessary to rely on dateLibrary, to obtain the currentMonth instead of using the JavaScript date.