### PR TITLE
Remove `@ember/render-modifiers`

### DIFF
--- a/ember-power-calendar/package.json
+++ b/ember-power-calendar/package.json
@@ -68,7 +68,6 @@
     "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "@embroider/util": "^1.13.0",
-    "@ember/render-modifiers": "^2.1.0",
     "@embroider/macros": "^1.15.0",
     "ember-assign-helper": "^0.5.0",
     "ember-element-helper": "^0.8.6",

--- a/ember-power-calendar/src/components/power-calendar-multiple.hbs
+++ b/ember-power-calendar/src/components/power-calendar-multiple.hbs
@@ -3,9 +3,7 @@
   Days=(component (ensure-safe-component (or @daysComponent this.daysComponent)) calendar=(readonly this.publicAPI))
 )) as |calendar|}}
   {{#let (element this.tagWithDefault) as |Tag|}}
-    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}
-      {{will-destroy this.destroyElement}}
-    >
+    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
       {{#if (has-block)}}
         {{yield calendar}}
       {{else}}

--- a/ember-power-calendar/src/components/power-calendar-multiple.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple.ts
@@ -80,6 +80,11 @@ export default class PowerCalendarMultipleComponent extends Component<PowerCalen
     }
   }
 
+  willDestroy(): void {
+    super.willDestroy();
+    this.unregisterCalendar();
+  }
+
   get publicActions(): PowerCalendarActions {
     return publicActionsObject(
       this.args.onSelect,
@@ -181,11 +186,6 @@ export default class PowerCalendarMultipleComponent extends Component<PowerCalen
         e,
       );
     }
-  }
-
-  @action
-  destroyElement() {
-    this.unregisterCalendar();
   }
 
   // Methods

--- a/ember-power-calendar/src/components/power-calendar-range.hbs
+++ b/ember-power-calendar/src/components/power-calendar-range.hbs
@@ -3,9 +3,7 @@
   Days=(component (ensure-safe-component (or @daysComponent this.daysComponent)) calendar=(readonly this.publicAPI))
 )) as |calendar|}}
   {{#let (element this.tagWithDefault) as |Tag|}}
-    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}
-      {{will-destroy this.destroyElement}}
-    >
+    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
       {{#if (has-block)}}
         {{yield calendar}}
       {{else}}

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -94,6 +94,11 @@ export default class PowerCalendarRangeComponent extends Component<PowerCalendar
     }
   }
 
+  willDestroy(): void {
+    super.willDestroy();
+    this.unregisterCalendar();
+  }
+
   get publicActions(): PowerCalendarActions {
     return publicActionsObject(
       this.args.onSelect,
@@ -227,11 +232,6 @@ export default class PowerCalendarRangeComponent extends Component<PowerCalendar
     if (this.args.onSelect) {
       this.args.onSelect(range, calendar as PowerCalendarRangeAPI, e);
     }
-  }
-
-  @action
-  destroyElement() {
-    this.unregisterCalendar();
   }
 
   _formatRange(v: number | undefined) {

--- a/ember-power-calendar/src/components/power-calendar.hbs
+++ b/ember-power-calendar/src/components/power-calendar.hbs
@@ -3,9 +3,7 @@
   Days=(component (ensure-safe-component (or @daysComponent this.daysComponent)) calendar=(readonly this.publicAPI))
 )) as |calendar|}}
   {{#let (element this.tagWithDefault) as |Tag|}}
-    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}
-      {{will-destroy this.destroyElement}}
-    >
+    <Tag class="ember-power-calendar" ...attributes id={{calendar.uniqueId}}>
       {{#if (has-block)}}
         {{yield calendar}}
       {{else}}

--- a/ember-power-calendar/src/components/power-calendar.ts
+++ b/ember-power-calendar/src/components/power-calendar.ts
@@ -121,6 +121,11 @@ export default class PowerCalendarComponent extends Component<PowerCalendarSigna
     }
   }
 
+  willDestroy(): void {
+    super.willDestroy();
+    this.unregisterCalendar();
+  }
+
   get publicActions(): PowerCalendarActions {
     return publicActionsObject(
       this.args.onSelect,
@@ -192,11 +197,6 @@ export default class PowerCalendarComponent extends Component<PowerCalendarSigna
     if (this.args.onSelect) {
       this.args.onSelect(day, calendar, e);
     }
-  }
-
-  @action
-  destroyElement() {
-    this.unregisterCalendar();
   }
 
   // Methods

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,9 +302,6 @@ importers:
 
   ember-power-calendar:
     dependencies:
-      '@ember/render-modifiers':
-        specifier: ^2.1.0
-        version: 2.1.0(@babel/core@7.24.3)(@glint/template@1.4.0)(ember-source@5.7.0)
       '@embroider/addon-shim':
         specifier: ^1.8.7
         version: 1.8.7
@@ -2117,6 +2114,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
 
   /@ember/string@3.1.1:
     resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
@@ -7254,6 +7252,7 @@ packages:
     dependencies:
       resolve: 1.22.8
       semver: 5.7.2
+    dev: true
 
   /ember-cli-version-checker@3.1.3:
     resolution: {integrity: sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==}
@@ -7558,6 +7557,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
 
   /ember-modifier@4.1.0(ember-source@5.7.0):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}


### PR DESCRIPTION
This PR removes all usages from `@ember/render-modifiers`.

`@ember/render-modifiers` were meant as a transitional tool from the pre-Octane era, and not long-term usage.

See: https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-at-ember-render-modifiers.md