### PR TITLE
Add support for css variables to mixin

### DIFF
--- a/ember-power-calendar/less/base.less
+++ b/ember-power-calendar/less/base.less
@@ -12,8 +12,7 @@
   box-sizing: border-box;
 }
 
-.ember-power-calendar-days,
-.ember-power-calendar-days * {
+.ember-power-calendar-days, .ember-power-calendar-days * {
   box-sizing: border-box;
 }
 
@@ -94,20 +93,20 @@
   @cell-size: null,
   @cell-width: @cell-size,
   @cell-height: @cell-size,
-  @cell-with-spacing-width: calc(~"@{cell-width} + 2px");
+  @cell-with-spacing-width: calc(~"@{cell-width} + 2px"),
   @row-padding-top: 0,
   @row-padding-bottom: 0,
   @row-padding-left: 0,
   @row-padding-right: 0,
-  @row-width: calc(~"(@{cell-with-spacing-width} * 7) - 2px + @{row-padding-left} + @{row-padding-right}");
-  @row-height: calc(~"@{cell-height} + 2px");
+  @row-width: calc(~"(@{cell-with-spacing-width} * 7) - 2px + @{row-padding-left} + @{row-padding-right}"),
+  @row-height: calc(~"@{cell-height} + 2px"),
   @primary-color: #0078c9,
   @nav-button-color: @primary-color,
   @nav-button-color--focus: lighten(@nav-button-color, 20%),
   @day-default-text-color: #bbb,
   @day-current-month-color: #F5F7FA,
   @day-weekday-text-color: #333333,
-  @day-current-month-text-color: #656d78,
+  @day-current-month-text-color: #656D78,
   @day-other-month-text-color--hover: @day-current-month-text-color,
   @day-focus-shadow-color: @primary-color,
   @day-today-color: #eee,
@@ -119,59 +118,57 @@
   @day-range-end-background-color--hover: @day-range-end-background-color,
   @day-selected-color: lighten(@primary-color, 50%),
   @day-selected-color--hover: @day-selected-color,
-  @day-selected-text-color: #656d78,
+  @day-selected-text-color: #656D78,
   @day-selected-text-color--hover: @day-selected-text-color
 ) {
   width: @row-width;
   .ember-power-calendar-week:first-child {
-    &[data-missing-days='1'] {
+    &[data-missing-days="1"] {
       padding-left: calc(~"@{cell-with-spacing-width} * 1");
     }
-    &[data-missing-days='2'] {
+    &[data-missing-days="2"] {
       padding-left: calc(~"@{cell-with-spacing-width} * 2");
     }
-    &[data-missing-days='3'] {
+    &[data-missing-days="3"] {
       padding-left: calc(~"@{cell-with-spacing-width} * 3");
     }
-    &[data-missing-days='4'] {
+    &[data-missing-days="4"] {
       padding-left: calc(~"@{cell-with-spacing-width} * 4");
     }
-    &[data-missing-days='5'] {
+    &[data-missing-days="5"] {
       padding-left: calc(~"@{cell-with-spacing-width} * 5");
     }
-    &[data-missing-days='6'] {
+    &[data-missing-days="6"] {
       padding-left: calc(~"@{cell-with-spacing-width} * 6");
     }
   }
   .ember-power-calendar-week:last-child {
-    &[data-missing-days='1'] {
+    &[data-missing-days="1"] {
       padding-right: calc(~"@{cell-with-spacing-width} * 1");
     }
-    &[data-missing-days='2'] {
+    &[data-missing-days="2"] {
       padding-right: calc(~"@{cell-with-spacing-width} * 2");
     }
-    &[data-missing-days='3'] {
+    &[data-missing-days="3"] {
       padding-right: calc(~"@{cell-with-spacing-width} * 3");
     }
-    &[data-missing-days='4'] {
+    &[data-missing-days="4"] {
       padding-right: calc(~"@{cell-with-spacing-width} * 4");
     }
-    &[data-missing-days='5'] {
+    &[data-missing-days="5"] {
       padding-right: calc(~"@{cell-with-spacing-width} * 5");
     }
-    &[data-missing-days='6'] {
+    &[data-missing-days="6"] {
       padding-right: calc(~"@{cell-with-spacing-width} * 6");
     }
   }
-  .ember-power-calendar-day,
-  .ember-power-calendar-weekday {
+  .ember-power-calendar-day, .ember-power-calendar-weekday {
     max-width: @cell-width;
     max-height: @cell-height;
     width: @cell-width;
     height: @cell-height;
   }
-  .ember-power-calendar-weekdays,
-  .ember-power-calendar-week {
+  .ember-power-calendar-weekdays, .ember-power-calendar-week {
     height: @row-height;
     padding-left: @row-padding-left;
     padding-right: @row-padding-right;

--- a/ember-power-calendar/less/base.less
+++ b/ember-power-calendar/less/base.less
@@ -12,7 +12,8 @@
   box-sizing: border-box;
 }
 
-.ember-power-calendar-days, .ember-power-calendar-days * {
+.ember-power-calendar-days,
+.ember-power-calendar-days * {
   box-sizing: border-box;
 }
 
@@ -93,20 +94,20 @@
   @cell-size: null,
   @cell-width: @cell-size,
   @cell-height: @cell-size,
-  @cell-with-spacing-width: @cell-width + 2px,
+  @cell-with-spacing-width: calc(~"@{cell-width} + 2px");
   @row-padding-top: 0,
   @row-padding-bottom: 0,
   @row-padding-left: 0,
   @row-padding-right: 0,
-  @row-width: @cell-with-spacing-width * 7 - 2px + @row-padding-left + @row-padding-right,
-  @row-height: @cell-height + 2px,
+  @row-width: calc(~"(@{cell-with-spacing-width} * 7) - 2px + @{row-padding-left} + @{row-padding-right}");
+  @row-height: calc(~"@{cell-height} + 2px");
   @primary-color: #0078c9,
   @nav-button-color: @primary-color,
   @nav-button-color--focus: lighten(@nav-button-color, 20%),
   @day-default-text-color: #bbb,
   @day-current-month-color: #F5F7FA,
   @day-weekday-text-color: #333333,
-  @day-current-month-text-color: #656D78,
+  @day-current-month-text-color: #656d78,
   @day-other-month-text-color--hover: @day-current-month-text-color,
   @day-focus-shadow-color: @primary-color,
   @day-today-color: #eee,
@@ -118,58 +119,59 @@
   @day-range-end-background-color--hover: @day-range-end-background-color,
   @day-selected-color: lighten(@primary-color, 50%),
   @day-selected-color--hover: @day-selected-color,
-  @day-selected-text-color: #656D78,
+  @day-selected-text-color: #656d78,
   @day-selected-text-color--hover: @day-selected-text-color
 ) {
-
   width: @row-width;
   .ember-power-calendar-week:first-child {
-    &[data-missing-days="1"] {
-      padding-left: @cell-with-spacing-width * 1;
+    &[data-missing-days='1'] {
+      padding-left: calc(~"@{cell-with-spacing-width} * 1");
     }
-    &[data-missing-days="2"] {
-      padding-left: @cell-with-spacing-width * 2;
+    &[data-missing-days='2'] {
+      padding-left: calc(~"@{cell-with-spacing-width} * 2");
     }
-    &[data-missing-days="3"] {
-      padding-left: @cell-with-spacing-width * 3;
+    &[data-missing-days='3'] {
+      padding-left: calc(~"@{cell-with-spacing-width} * 3");
     }
-    &[data-missing-days="4"] {
-      padding-left: @cell-with-spacing-width * 4;
+    &[data-missing-days='4'] {
+      padding-left: calc(~"@{cell-with-spacing-width} * 4");
     }
-    &[data-missing-days="5"] {
-      padding-left: @cell-with-spacing-width * 5;
+    &[data-missing-days='5'] {
+      padding-left: calc(~"@{cell-with-spacing-width} * 5");
     }
-    &[data-missing-days="6"] {
-      padding-left: @cell-with-spacing-width * 6;
+    &[data-missing-days='6'] {
+      padding-left: calc(~"@{cell-with-spacing-width} * 6");
     }
   }
   .ember-power-calendar-week:last-child {
-    &[data-missing-days="1"] {
-      padding-right: @cell-with-spacing-width * 1;
+    &[data-missing-days='1'] {
+      padding-right: calc(~"@{cell-with-spacing-width} * 1");
     }
-    &[data-missing-days="2"] {
-      padding-right: @cell-with-spacing-width * 2;
+    &[data-missing-days='2'] {
+      padding-right: calc(~"@{cell-with-spacing-width} * 2");
     }
-    &[data-missing-days="3"] {
-      padding-right: @cell-with-spacing-width * 3;
+    &[data-missing-days='3'] {
+      padding-right: calc(~"@{cell-with-spacing-width} * 3");
     }
-    &[data-missing-days="4"] {
-      padding-right: @cell-with-spacing-width * 4;
+    &[data-missing-days='4'] {
+      padding-right: calc(~"@{cell-with-spacing-width} * 4");
     }
-    &[data-missing-days="5"] {
-      padding-right: @cell-with-spacing-width * 5;
+    &[data-missing-days='5'] {
+      padding-right: calc(~"@{cell-with-spacing-width} * 5");
     }
-    &[data-missing-days="6"] {
-      padding-right: @cell-with-spacing-width * 6;
+    &[data-missing-days='6'] {
+      padding-right: calc(~"@{cell-with-spacing-width} * 6");
     }
   }
-  .ember-power-calendar-day, .ember-power-calendar-weekday {
+  .ember-power-calendar-day,
+  .ember-power-calendar-weekday {
     max-width: @cell-width;
     max-height: @cell-height;
     width: @cell-width;
     height: @cell-height;
   }
-  .ember-power-calendar-weekdays, .ember-power-calendar-week {
+  .ember-power-calendar-weekdays,
+  .ember-power-calendar-week {
     height: @row-height;
     padding-left: @row-padding-left;
     padding-right: @row-padding-right;

--- a/ember-power-calendar/scss/base.scss
+++ b/ember-power-calendar/scss/base.scss
@@ -90,15 +90,15 @@
   $cell-size: null,
   $cell-width: $cell-size,
   $cell-height: $cell-size,
-  $cell-with-spacing-width: $cell-width + 2px,
+  $cell-with-spacing-width: calc(#{$cell-width} + 2px)
   $row-padding-top: 0,
   $row-padding-bottom: 0,
   $row-padding-left: 0,
   $row-padding-right: 0,
-  $row-width: (
-    $cell-with-spacing-width * 7 - 2px + $row-padding-left + $row-padding-right,
+  $row-width: calc(
+    #{$cell-with-spacing-width} * 7 - 2px + #{$row-padding-left} + #{$row-padding-right},
   ),
-  $row-height: $cell-height + 2px,
+  $row-height: calc(#{$cell-height} + 2px),
   $primary-color: #0078c9,
   $nav-button-color: $primary-color,
   $nav-button-color--focus: lighten($nav-button-color, 20%),
@@ -124,53 +124,53 @@
 
   .ember-power-calendar-week:first-child {
     &[data-missing-days="1"] {
-      padding-left: $cell-with-spacing-width * 1;
+      padding-left: calc(#{$cell-with-spacing-width} * 1);
     }
 
     &[data-missing-days="2"] {
-      padding-left: $cell-with-spacing-width * 2;
+      padding-left: calc(#{$cell-with-spacing-width} * 2);
     }
 
     &[data-missing-days="3"] {
-      padding-left: $cell-with-spacing-width * 3;
+      padding-left: calc(#{$cell-with-spacing-width} * 3);
     }
 
     &[data-missing-days="4"] {
-      padding-left: $cell-with-spacing-width * 4;
+      padding-left: calc(#{$cell-with-spacing-width} * 4);
     }
 
     &[data-missing-days="5"] {
-      padding-left: $cell-with-spacing-width * 5;
+      padding-left: calc(#{$cell-with-spacing-width} * 5);
     }
 
     &[data-missing-days="6"] {
-      padding-left: $cell-with-spacing-width * 6;
+      padding-left: calc(#{$cell-with-spacing-width} * 6);
     }
   }
 
   .ember-power-calendar-week:last-child {
     &[data-missing-days="1"] {
-      padding-right: $cell-with-spacing-width * 1;
+      padding-right: calc(#{$cell-with-spacing-width} * 1);
     }
 
     &[data-missing-days="2"] {
-      padding-right: $cell-with-spacing-width * 2;
+      padding-right: calc(#{$cell-with-spacing-width} * 2);
     }
 
     &[data-missing-days="3"] {
-      padding-right: $cell-with-spacing-width * 3;
+      padding-right: calc(#{$cell-with-spacing-width} * 3);
     }
 
     &[data-missing-days="4"] {
-      padding-right: $cell-with-spacing-width * 4;
+      padding-right: calc(#{$cell-with-spacing-width} * 4);
     }
 
     &[data-missing-days="5"] {
-      padding-right: $cell-with-spacing-width * 5;
+      padding-right: calc(#{$cell-with-spacing-width} * 5);
     }
 
     &[data-missing-days="6"] {
-      padding-right: $cell-with-spacing-width * 6;
+      padding-right: calc(#{$cell-with-spacing-width} * 6);
     }
   }
 

--- a/ember-power-calendar/scss/base.scss
+++ b/ember-power-calendar/scss/base.scss
@@ -124,53 +124,53 @@
   width: $row-width;
 
   .ember-power-calendar-week:first-child {
-    &[data-missing-days='1'] {
+    &[data-missing-days="1"] {
       padding-left: calc(#{$cell-with-spacing-width} * 1);
     }
 
-    &[data-missing-days='2'] {
+    &[data-missing-days="2"] {
       padding-left: calc(#{$cell-with-spacing-width} * 2);
     }
 
-    &[data-missing-days='3'] {
+    &[data-missing-days="3"] {
       padding-left: calc(#{$cell-with-spacing-width} * 3);
     }
 
-    &[data-missing-days='4'] {
+    &[data-missing-days="4"] {
       padding-left: calc(#{$cell-with-spacing-width} * 4);
     }
 
-    &[data-missing-days='5'] {
+    &[data-missing-days="5"] {
       padding-left: calc(#{$cell-with-spacing-width} * 5);
     }
 
-    &[data-missing-days='6'] {
+    &[data-missing-days="6"] {
       padding-left: calc(#{$cell-with-spacing-width} * 6);
     }
   }
 
   .ember-power-calendar-week:last-child {
-    &[data-missing-days='1'] {
+    &[data-missing-days="1"] {
       padding-right: calc(#{$cell-with-spacing-width} * 1);
     }
 
-    &[data-missing-days='2'] {
+    &[data-missing-days="2"] {
       padding-right: calc(#{$cell-with-spacing-width} * 2);
     }
 
-    &[data-missing-days='3'] {
+    &[data-missing-days="3"] {
       padding-right: calc(#{$cell-with-spacing-width} * 3);
     }
 
-    &[data-missing-days='4'] {
+    &[data-missing-days="4"] {
       padding-right: calc(#{$cell-with-spacing-width} * 4);
     }
 
-    &[data-missing-days='5'] {
+    &[data-missing-days="5"] {
       padding-right: calc(#{$cell-with-spacing-width} * 5);
     }
 
-    &[data-missing-days='6'] {
+    &[data-missing-days="6"] {
       padding-right: calc(#{$cell-with-spacing-width} * 6);
     }
   }

--- a/ember-power-calendar/scss/base.scss
+++ b/ember-power-calendar/scss/base.scss
@@ -90,14 +90,15 @@
   $cell-size: null,
   $cell-width: $cell-size,
   $cell-height: $cell-size,
-  $cell-with-spacing-width: calc(#{$cell-width} + 2px)
+  $cell-with-spacing-width: calc(#{$cell-width} + 2px),
   $row-padding-top: 0,
   $row-padding-bottom: 0,
   $row-padding-left: 0,
   $row-padding-right: 0,
-  $row-width: calc(
-    #{$cell-with-spacing-width} * 7 - 2px + #{$row-padding-left} + #{$row-padding-right},
-  ),
+  $row-width:
+    calc(
+      #{$cell-with-spacing-width} * 7 - 2px + #{$row-padding-left} + #{$row-padding-right}
+    ),
   $row-height: calc(#{$cell-height} + 2px),
   $primary-color: #0078c9,
   $nav-button-color: $primary-color,
@@ -123,53 +124,53 @@
   width: $row-width;
 
   .ember-power-calendar-week:first-child {
-    &[data-missing-days="1"] {
+    &[data-missing-days='1'] {
       padding-left: calc(#{$cell-with-spacing-width} * 1);
     }
 
-    &[data-missing-days="2"] {
+    &[data-missing-days='2'] {
       padding-left: calc(#{$cell-with-spacing-width} * 2);
     }
 
-    &[data-missing-days="3"] {
+    &[data-missing-days='3'] {
       padding-left: calc(#{$cell-with-spacing-width} * 3);
     }
 
-    &[data-missing-days="4"] {
+    &[data-missing-days='4'] {
       padding-left: calc(#{$cell-with-spacing-width} * 4);
     }
 
-    &[data-missing-days="5"] {
+    &[data-missing-days='5'] {
       padding-left: calc(#{$cell-with-spacing-width} * 5);
     }
 
-    &[data-missing-days="6"] {
+    &[data-missing-days='6'] {
       padding-left: calc(#{$cell-with-spacing-width} * 6);
     }
   }
 
   .ember-power-calendar-week:last-child {
-    &[data-missing-days="1"] {
+    &[data-missing-days='1'] {
       padding-right: calc(#{$cell-with-spacing-width} * 1);
     }
 
-    &[data-missing-days="2"] {
+    &[data-missing-days='2'] {
       padding-right: calc(#{$cell-with-spacing-width} * 2);
     }
 
-    &[data-missing-days="3"] {
+    &[data-missing-days='3'] {
       padding-right: calc(#{$cell-with-spacing-width} * 3);
     }
 
-    &[data-missing-days="4"] {
+    &[data-missing-days='4'] {
       padding-right: calc(#{$cell-with-spacing-width} * 4);
     }
 
-    &[data-missing-days="5"] {
+    &[data-missing-days='5'] {
       padding-right: calc(#{$cell-with-spacing-width} * 5);
     }
 
-    &[data-missing-days="6"] {
+    &[data-missing-days='6'] {
       padding-right: calc(#{$cell-with-spacing-width} * 6);
     }
   }


### PR DESCRIPTION
While migrating from scss to css variables, we bumped into some issues with the ember power calendar mixin:

` codeFrame: Error: Undefined operation "calc(32px + var(--our-variable)) * 1".
    ╷
128 │       padding-left: $cell-with-spacing-width * 1;
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
  /tmp/broccoli-474vURcC73g1RJ/out-944-funnel_funnel_styles/app/styles/ember-power-calendar.scss 128:21       ember-power-calendar()`

This code would make it possible to use css variables in the scss variables needed for the ember power calendar mixin.