### PR TITLE
Add missing mixin css part in generated css file (vanilla css)

### DIFF
--- a/ember-power-calendar/ember-power-calendar-for-css-generate.scss
+++ b/ember-power-calendar/ember-power-calendar-for-css-generate.scss
@@ -1,0 +1,9 @@
+:root {
+  --ember-power-calendar-cell-size: 35px;
+}
+
+@import './ember-power-calendar.scss';
+
+.ember-power-calendar {
+  @include ember-power-calendar($cell-size: 'var(--ember-power-calendar-cell-size)');
+}

--- a/ember-power-calendar/rollup.config.mjs
+++ b/ember-power-calendar/rollup.config.mjs
@@ -10,7 +10,7 @@ const addon = new Addon({
 export default [
   // Compile scss file for js import
   {
-    input: './_index.scss',
+    input: './ember-power-calendar-for-css-generate.scss',
     output: {
       file: './vendor/ember-power-calendar.js',
       assetFileNames: '[name][extname]',


### PR DESCRIPTION
While css variable introducing we have discovered that in generated css there was missing the css part which comes from mixin.