### PR TITLE
chore: allow `@ember/test-helpers` v4 peer

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
-    "@ember/test-helpers": "^3.3.0",
+    "@ember/test-helpers": "^4.0.0",
     "@embroider/macros": "^1.16.4",
     "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",

--- a/ember-power-calendar/package.json
+++ b/ember-power-calendar/package.json
@@ -156,7 +156,7 @@
     }
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.9.4 || ^3.2.1",
+    "@ember/test-helpers": "^2.9.4 || ^3.2.1 || ^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "ember-concurrency": "^4.0.2",

--- a/ember-power-calendar/package.json
+++ b/ember-power-calendar/package.json
@@ -77,7 +77,7 @@
     "@babel/runtime": "^7.24.7",
     "@babel/plugin-transform-typescript": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
-    "@ember/test-helpers": "^3.3.0",
+    "@ember/test-helpers": "^4.0.0",
     "@embroider/addon-dev": "^4.3.1",
     "@glint/core": "^1.4.0",
     "@glint/environment-ember-loose": "^1.4.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
-    "@ember/test-helpers": "^3.3.0",
+    "@ember/test-helpers": "^4.0.0",
     "@embroider/macros": "^1.16.4",
     "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",


### PR DESCRIPTION
Allow test-helpers v4

Unfortunately I can't run pnpm install for this repo on my system, node-sass / node-gyp fail to install binaries (running macos w/ M2 chip). If someone could run that, that would be helpful