### PR TITLE
Update `date-fns` meta package link

### DIFF
--- a/docs/app/templates/public-pages/docs/installation.hbs
+++ b/docs/app/templates/public-pages/docs/installation.hbs
@@ -27,7 +27,7 @@
 <ul>
   <li><a href="https://github.com/cibernox/ember-power-calendar-luxon">Ember Power Calendar Luxon</a></li>
   <li><a href="https://github.com/cibernox/ember-power-calendar-moment">Ember Power Calendar Moment</a></li>
-  <li><a href="https://github.com/makepanic/ember-power-calendar-date-fns">Ember Power Calendar date-fns</a></li>
+  <li><a href="https://github.com/ember-power-addons/ember-power-calendar-date-fns">Ember Power Calendar date-fns</a></li>
 </ul>
 
 <p>


### PR DESCRIPTION
The current [date-fns meta package](https://github.com/makepanic/ember-power-calendar-date-fns) is outdated and maintainer is inactive.

Now we have created a completly new `date-fns` meta package for power-calendar which will be supported from us https://github.com/ember-power-addons/ember-power-calendar-date-fns