### PR TITLE
Fix css variable in vendor css

### DIFF
--- a/ember-power-calendar/ember-power-calendar-for-css-generate.scss
+++ b/ember-power-calendar/ember-power-calendar-for-css-generate.scss
@@ -5,5 +5,5 @@
 @import './ember-power-calendar.scss';
 
 .ember-power-calendar {
-  @include ember-power-calendar($cell-size: 'var(--ember-power-calendar-cell-size)');
+  @include ember-power-calendar($cell-size: var(--ember-power-calendar-cell-size));
 }


### PR DESCRIPTION
The scss to css convert brings for exaample:

```css
.ember-power-calendar .ember-power-calendar-day, .ember-power-calendar .ember-power-calendar-weekday {
  max-width: "var(--ember-power-calendar-cell-size)";
  max-height: "var(--ember-power-calendar-cell-size)";
  width: "var(--ember-power-calendar-cell-size)";
  height: "var(--ember-power-calendar-cell-size)";
}
```

Css variables aren't working in this case

After this fix the css variables are working:

```css
.ember-power-calendar .ember-power-calendar-day, .ember-power-calendar .ember-power-calendar-weekday {
  max-width: var(--ember-power-calendar-cell-size);
  max-height: var(--ember-power-calendar-cell-size);
  width: var(--ember-power-calendar-cell-size);
  height: var(--ember-power-calendar-cell-size);
}
```