### PR TITLE
Improve typescript story

### DIFF
--- a/ember-power-calendar/eslint.config.mjs
+++ b/ember-power-calendar/eslint.config.mjs
@@ -79,11 +79,6 @@ export default ts.config(
     },
     extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-misused-promises': 'off',
-      '@typescript-eslint/unbound-method': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/await-thenable': 'off',
       'ember/no-runloop': 0,
     },
   },

--- a/ember-power-calendar/src/-private/utils.ts
+++ b/ember-power-calendar/src/-private/utils.ts
@@ -5,7 +5,7 @@ import type {
   PowerCalendarActions,
   TPowerCalendarOnSelect,
 } from '../components/power-calendar';
-import { add } from '../utils.ts';
+import { add, type NormalizeCalendarValue } from '../utils.ts';
 import type { TPowerCalendarRangeOnSelect } from '../components/power-calendar-range';
 import type { TPowerCalendarMultipleOnSelect } from '../components/power-calendar-multiple.ts';
 
@@ -17,7 +17,11 @@ export function publicActionsObject(
     | undefined,
   select: (day: CalendarDay, calendar: CalendarAPI, e: MouseEvent) => void,
   onCenterChange:
-    | ((newCenter: any, calendar: CalendarAPI, event: MouseEvent) => void)
+    | ((
+        newCenter: NormalizeCalendarValue,
+        calendar: CalendarAPI,
+        event: MouseEvent,
+      ) => Promise<void>)
     | undefined,
   changeCenterTask: TaskForAsyncTaskFunction<
     unknown,
@@ -38,9 +42,9 @@ export function publicActionsObject(
       return changeCenterTask.perform(newCenter, calendar, e);
     };
     actions.changeCenter = changeCenter;
-    actions.moveCenter = (step, unit, calendar, e) => {
+    actions.moveCenter = async (step, unit, calendar, e) => {
       const newCenter = add(currentCenter, step, unit);
-      return changeCenter(newCenter, calendar, e);
+      return await changeCenter(newCenter, calendar, e);
     };
   }
 

--- a/ember-power-calendar/src/components/power-calendar-multiple/days.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple/days.ts
@@ -140,14 +140,14 @@ export default class PowerCalendarMultipleDaysComponent extends Component<PowerC
     scheduleOnce(
       'actions',
       this,
-      this._updateFocused,
+      this._updateFocused.bind(this),
       (e.target as HTMLElement).dataset['date'],
     );
   }
 
   @action
   handleDayBlur(): void {
-    scheduleOnce('actions', this, this._updateFocused, null);
+    scheduleOnce('actions', this, this._updateFocused.bind(this), null);
   }
 
   @action

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -22,7 +22,6 @@ import {
 } from '../utils.ts';
 import type {
   PowerCalendarAPI,
-  PowerCalendarSignature,
   PowerCalendarArgs,
   TCalendarType,
   SelectedDays,
@@ -56,12 +55,12 @@ interface PowerCalendarRangeArgs
 }
 
 export interface PowerCalendarRangeDefaultBlock extends PowerCalendarRangeAPI {
-  NavComponent: ComponentLike<any>;
-  DaysComponent: ComponentLike<any>;
+  NavComponent: ComponentLike<PowerCalendarNavComponent>;
+  DaysComponent: ComponentLike<PowerCalendarRangeDaysComponent>;
 }
 
-interface PowerCalendarRangeSignature
-  extends Omit<PowerCalendarSignature, 'Args' | 'Blocks'> {
+interface PowerCalendarRangeSignature {
+  Element: HTMLElement;
   Args: PowerCalendarRangeArgs;
   Blocks: {
     default: [PowerCalendarRangeDefaultBlock];
@@ -82,8 +81,8 @@ export default class PowerCalendarRangeComponent extends Component<PowerCalendar
   @tracked _calendarType: TCalendarType = 'range';
   @tracked _selected?: SelectedDays;
 
-  navComponent: ComponentLike<any> = PowerCalendarNavComponent;
-  daysComponent: ComponentLike<any> = PowerCalendarRangeDaysComponent;
+  navComponent = PowerCalendarNavComponent;
+  daysComponent = PowerCalendarRangeDaysComponent;
 
   // Lifecycle hooks
   constructor(owner: Owner, args: PowerCalendarRangeArgs) {
@@ -102,7 +101,7 @@ export default class PowerCalendarRangeComponent extends Component<PowerCalendar
   get publicActions(): PowerCalendarActions {
     return publicActionsObject(
       this.args.onSelect,
-      this.select,
+      this.select.bind(this),
       this.args.onCenterChange,
       this.changeCenterTask,
       this.currentCenter,
@@ -306,19 +305,22 @@ export default class PowerCalendarRangeComponent extends Component<PowerCalendar
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       window.__powerCalendars = window.__powerCalendars || {}; // TODO: weakmap??
       // @ts-expect-error Property '__powerCalendars'
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       window.__powerCalendars[this.publicAPI.uniqueId] = this;
     }
   }
 
   unregisterCalendar() {
     // @ts-expect-error Property '__powerCalendars'
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (window && window.__powerCalendars?.[guidFor(this)]) {
       // @ts-expect-error Property '__powerCalendars'
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       delete window.__powerCalendars[guidFor(this)];
     }
   }
 }
 
-function ownProp<T = { [key: string | number]: any }>(obj: T, prop: keyof T) {
+function ownProp<T = { [key: string | number]: never }>(obj: T, prop: keyof T) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }

--- a/ember-power-calendar/src/components/power-calendar-range/days.ts
+++ b/ember-power-calendar/src/components/power-calendar-range/days.ts
@@ -126,14 +126,14 @@ export default class PowerCalendarRangeDaysComponent extends Component<PowerCale
     scheduleOnce(
       'actions',
       this,
-      this._updateFocused,
+      this._updateFocused.bind(this),
       (e.target as HTMLElement).dataset['date'],
     );
   }
 
   @action
   handleDayBlur(): void {
-    scheduleOnce('actions', this, this._updateFocused, null);
+    scheduleOnce('actions', this, this._updateFocused.bind(this), null);
   }
 
   @action

--- a/ember-power-calendar/src/components/power-calendar/days.ts
+++ b/ember-power-calendar/src/components/power-calendar/days.ts
@@ -137,14 +137,14 @@ export default class PowerCalendarDaysComponent extends Component<PowerCalendarD
     scheduleOnce(
       'actions',
       this,
-      this._updateFocused,
+      this._updateFocused.bind(this),
       (e.target as HTMLElement).dataset['date'],
     );
   }
 
   @action
   handleDayBlur(): void {
-    scheduleOnce('actions', this, this._updateFocused, null);
+    scheduleOnce('actions', this, this._updateFocused.bind(this), null);
   }
 
   @action

--- a/ember-power-calendar/src/test-support/helpers.ts
+++ b/ember-power-calendar/src/test-support/helpers.ts
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { assert } from '@ember/debug';
 import { click, settled, find } from '@ember/test-helpers';
 import { formatDate } from '../utils.ts';
@@ -49,7 +48,7 @@ function findComponentInstance(
     calendarGuid,
   );
   // @ts-expect-error Property '__powerCalendars'
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
   return window.__powerCalendars[calendarGuid];
 }
 
@@ -68,9 +67,7 @@ export async function calendarCenter(
     !!onCenterChange,
   );
   const publicAPI = calendarComponent.publicAPI;
-  run(() =>
-    publicAPI.actions.changeCenter!(newCenter, publicAPI, {} as MouseEvent),
-  );
+  await publicAPI.actions.changeCenter!(newCenter, publicAPI, {} as MouseEvent);
   return settled();
 }
 

--- a/ember-power-calendar/src/types/global.d.ts
+++ b/ember-power-calendar/src/types/global.d.ts
@@ -4,10 +4,12 @@ import type EmberTruthRegistry from 'ember-truth-helpers/template-registry';
 import type { EmbroiderUtilRegistry } from '@embroider/util';
 
 export interface AssignRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 
 export interface ReadonlyRegistry {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 


### PR DESCRIPTION
After updating to ember 6.1 there was necessary to disable some eslint rules for typescript, as it follows not recommendedTypechecked with flat config.

This PR removes now finally all any usages inside the addon and we do also fix some incorrect typings.

We do ship this changes in v1 story (also when it is possible braking for consumers), because the typing were not correctly