### PR TITLE
Fix memory leak of `window.__powerCalendars` (remove hash when empty)

### DIFF
--- a/ember-power-calendar/src/components/power-calendar-multiple.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple.ts
@@ -226,6 +226,13 @@ export default class PowerCalendarMultipleComponent extends Component<PowerCalen
       // @ts-expect-error Property '__powerCalendars'
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       delete window.__powerCalendars[guidFor(this)];
+
+      // @ts-expect-error Property '__powerCalendars'
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      if (Object.keys(window.__powerCalendars).length === 0) {
+        // @ts-expect-error Property '__powerCalendars'
+        delete window.__powerCalendars;
+      }
     }
   }
 }

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -317,6 +317,13 @@ export default class PowerCalendarRangeComponent extends Component<PowerCalendar
       // @ts-expect-error Property '__powerCalendars'
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       delete window.__powerCalendars[guidFor(this)];
+
+      // @ts-expect-error Property '__powerCalendars'
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      if (Object.keys(window.__powerCalendars).length === 0) {
+        // @ts-expect-error Property '__powerCalendars'
+        delete window.__powerCalendars;
+      }
     }
   }
 }

--- a/ember-power-calendar/src/components/power-calendar.ts
+++ b/ember-power-calendar/src/components/power-calendar.ts
@@ -218,6 +218,13 @@ export default class PowerCalendarComponent extends Component<PowerCalendarSigna
       // @ts-expect-error Property '__powerCalendars'
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       delete window.__powerCalendars[guidFor(this)];
+
+      // @ts-expect-error Property '__powerCalendars'
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      if (Object.keys(window.__powerCalendars).length === 0) {
+        // @ts-expect-error Property '__powerCalendars'
+        delete window.__powerCalendars;
+      }
     }
   }
 }

--- a/ember-power-calendar/src/test-support/helpers.ts
+++ b/ember-power-calendar/src/test-support/helpers.ts
@@ -49,7 +49,7 @@ function findComponentInstance(
   );
   // @ts-expect-error Property '__powerCalendars'
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-  return window.__powerCalendars[calendarGuid];
+  return window.__powerCalendars?.[calendarGuid];
 }
 
 export async function calendarCenter(


### PR DESCRIPTION
Addresses #542 