### PR TITLE
Fix typing for glint

### DIFF
--- a/ember-power-calendar/src/components/power-calendar-multiple.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple.ts
@@ -50,8 +50,8 @@ interface PowerCalendarMultipleArgs
 }
 
 interface PowerCalendarMultipleDefaultBlock extends PowerCalendarMultipleAPI {
-  NavComponent: ComponentLike<PowerCalendarNavComponent>;
-  DaysComponent: ComponentLike<PowerCalendarMultipleDaysComponent>;
+  Nav: ComponentLike<PowerCalendarNavComponent>;
+  Days: ComponentLike<PowerCalendarMultipleDaysComponent>;
 }
 
 interface PowerCalendarMultipleSignature {

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -55,8 +55,8 @@ interface PowerCalendarRangeArgs
 }
 
 export interface PowerCalendarRangeDefaultBlock extends PowerCalendarRangeAPI {
-  NavComponent: ComponentLike<PowerCalendarNavComponent>;
-  DaysComponent: ComponentLike<PowerCalendarRangeDaysComponent>;
+  Nav: ComponentLike<PowerCalendarNavComponent>;
+  Days: ComponentLike<PowerCalendarRangeDaysComponent>;
 }
 
 interface PowerCalendarRangeSignature {

--- a/ember-power-calendar/src/components/power-calendar.ts
+++ b/ember-power-calendar/src/components/power-calendar.ts
@@ -70,7 +70,7 @@ export type TPowerCalendarOnSelect = (
 
 export interface PowerCalendarArgs {
   daysComponent?: string | ComponentLike<PowerCalendarDaysComponent>;
-  locale: string;
+  locale?: string;
   navComponent?: string | ComponentLike<PowerCalendarNavComponent>;
   onCenterChange?: (
     newCenter: NormalizeCalendarValue,
@@ -85,8 +85,8 @@ export interface PowerCalendarArgs {
 }
 
 export interface PowerCalendarDefaultBlock extends PowerCalendarAPI {
-  NavComponent: ComponentLike<PowerCalendarNavComponent>;
-  DaysComponent: ComponentLike<PowerCalendarDaysComponent>;
+  Nav: ComponentLike<PowerCalendarNavComponent>;
+  Days: ComponentLike<PowerCalendarDaysComponent>;
 }
 
 export type CalendarDay =


### PR DESCRIPTION
While moving inside project to gts files i discoverd some glint issues (incorrect typings)

- locale is optional (by default it comes from service)
- yield paramter keys is incorrect