### PR TITLE
Fix `ComponentLike` (glint)

### DIFF
--- a/ember-power-calendar/src/components/power-calendar-multiple.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple.ts
@@ -6,8 +6,8 @@ import { assert } from '@ember/debug';
 import { isArray } from '@ember/array';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
-import PowerCalendarMultipleDaysComponent from './power-calendar-multiple/days.ts';
-import PowerCalendarNavComponent from './power-calendar/nav.ts';
+import PowerCalendarMultipleDaysComponent, { type PowerCalendarMultipleDaysSignature } from './power-calendar-multiple/days.ts';
+import PowerCalendarNavComponent, { type PowerCalendarNavSignature } from './power-calendar/nav.ts';
 import { publicActionsObject } from '../-private/utils.ts';
 import {
   normalizeDate,
@@ -33,7 +33,7 @@ import type PowerCalendarService from '../services/power-calendar.ts';
 export interface PowerCalendarMultipleAPI
   extends Omit<PowerCalendarAPI, 'selected' | 'DaysComponent'> {
   selected?: Date[];
-  DaysComponent: ComponentLike<PowerCalendarMultipleDaysComponent>;
+  DaysComponent: ComponentLike<PowerCalendarMultipleDaysSignature>;
 }
 
 export type TPowerCalendarMultipleOnSelect = (
@@ -45,13 +45,13 @@ export type TPowerCalendarMultipleOnSelect = (
 interface PowerCalendarMultipleArgs
   extends Omit<PowerCalendarArgs, 'selected' | 'daysComponent' | 'onSelect'> {
   selected?: Date[];
-  daysComponent?: string | ComponentLike<PowerCalendarMultipleDaysComponent>;
+  daysComponent?: string | ComponentLike<PowerCalendarMultipleDaysSignature>;
   onSelect?: TPowerCalendarMultipleOnSelect;
 }
 
 interface PowerCalendarMultipleDefaultBlock extends PowerCalendarMultipleAPI {
-  Nav: ComponentLike<PowerCalendarNavComponent>;
-  Days: ComponentLike<PowerCalendarMultipleDaysComponent>;
+  Nav: ComponentLike<PowerCalendarNavSignature>;
+  Days: ComponentLike<PowerCalendarMultipleDaysSignature>;
 }
 
 interface PowerCalendarMultipleSignature {

--- a/ember-power-calendar/src/components/power-calendar-multiple.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple.ts
@@ -6,8 +6,12 @@ import { assert } from '@ember/debug';
 import { isArray } from '@ember/array';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
-import PowerCalendarMultipleDaysComponent, { type PowerCalendarMultipleDaysSignature } from './power-calendar-multiple/days.ts';
-import PowerCalendarNavComponent, { type PowerCalendarNavSignature } from './power-calendar/nav.ts';
+import PowerCalendarMultipleDaysComponent, {
+  type PowerCalendarMultipleDaysSignature,
+} from './power-calendar-multiple/days.ts';
+import PowerCalendarNavComponent, {
+  type PowerCalendarNavSignature,
+} from './power-calendar/nav.ts';
 import { publicActionsObject } from '../-private/utils.ts';
 import {
   normalizeDate,

--- a/ember-power-calendar/src/components/power-calendar-multiple/days.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple/days.ts
@@ -42,7 +42,7 @@ interface PowerCalendarMultipleDaysArgs
   maxLength?: number;
 }
 
-interface PowerCalendarMultipleDaysSignature
+export interface PowerCalendarMultipleDaysSignature
   extends Omit<PowerCalendarDaysSignature, 'Args'> {
   Args: PowerCalendarMultipleDaysArgs;
 }

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -5,8 +5,12 @@ import { inject as service } from '@ember/service';
 import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
 import { task } from 'ember-concurrency';
-import PowerCalendarRangeDaysComponent, { type PowerCalendarRangeDaysSignature } from './power-calendar-range/days.ts';
-import PowerCalendarNavComponent, { type PowerCalendarNavSignature } from './power-calendar/nav.ts';
+import PowerCalendarRangeDaysComponent, {
+  type PowerCalendarRangeDaysSignature,
+} from './power-calendar-range/days.ts';
+import PowerCalendarNavComponent, {
+  type PowerCalendarNavSignature,
+} from './power-calendar/nav.ts';
 import { publicActionsObject } from '../-private/utils.ts';
 import {
   normalizeDate,

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
 import { task } from 'ember-concurrency';
-import PowerCalendarRangeDaysComponent from './power-calendar-range/days.ts';
-import PowerCalendarNavComponent from './power-calendar/nav.ts';
+import PowerCalendarRangeDaysComponent, { type PowerCalendarRangeDaysSignature } from './power-calendar-range/days.ts';
+import PowerCalendarNavComponent, { type PowerCalendarNavSignature } from './power-calendar/nav.ts';
 import { publicActionsObject } from '../-private/utils.ts';
 import {
   normalizeDate,
@@ -55,8 +55,8 @@ interface PowerCalendarRangeArgs
 }
 
 export interface PowerCalendarRangeDefaultBlock extends PowerCalendarRangeAPI {
-  Nav: ComponentLike<PowerCalendarNavComponent>;
-  Days: ComponentLike<PowerCalendarRangeDaysComponent>;
+  Nav: ComponentLike<PowerCalendarNavSignature>;
+  Days: ComponentLike<PowerCalendarRangeDaysSignature>;
 }
 
 interface PowerCalendarRangeSignature {

--- a/ember-power-calendar/src/components/power-calendar-range/days.ts
+++ b/ember-power-calendar/src/components/power-calendar-range/days.ts
@@ -44,12 +44,12 @@ interface PowerCalendarMultipleDaysArgs
   };
 }
 
-interface PowerCalendarRangeSignature
+export interface PowerCalendarRangeDaysSignature
   extends Omit<PowerCalendarDaysSignature, 'Args'> {
   Args: PowerCalendarMultipleDaysArgs;
 }
 
-export default class PowerCalendarRangeDaysComponent extends Component<PowerCalendarRangeSignature> {
+export default class PowerCalendarRangeDaysComponent extends Component<PowerCalendarRangeDaysSignature> {
   @service declare powerCalendar: PowerCalendarService;
 
   @tracked focusedId: string | null = null;

--- a/ember-power-calendar/src/components/power-calendar.ts
+++ b/ember-power-calendar/src/components/power-calendar.ts
@@ -13,8 +13,8 @@ import {
   type PowerCalendarDay,
   type SelectedPowerCalendarRange,
 } from '../utils.ts';
-import PowerCalendarNavComponent from './power-calendar/nav.ts';
-import PowerCalendarDaysComponent from './power-calendar/days.ts';
+import PowerCalendarNavComponent, { type PowerCalendarNavSignature } from './power-calendar/nav.ts';
+import PowerCalendarDaysComponent, { type PowerCalendarDaysSignature } from './power-calendar/days.ts';
 import type Owner from '@ember/owner';
 import type PowerCalendarService from '../services/power-calendar.ts';
 import type {
@@ -69,9 +69,9 @@ export type TPowerCalendarOnSelect = (
 ) => void;
 
 export interface PowerCalendarArgs {
-  daysComponent?: string | ComponentLike<PowerCalendarDaysComponent>;
+  daysComponent?: string | ComponentLike<PowerCalendarDaysSignature>;
   locale?: string;
-  navComponent?: string | ComponentLike<PowerCalendarNavComponent>;
+  navComponent?: string | ComponentLike<PowerCalendarNavSignature>;
   onCenterChange?: (
     newCenter: NormalizeCalendarValue,
     calendar: PowerCalendarAPI,
@@ -85,8 +85,8 @@ export interface PowerCalendarArgs {
 }
 
 export interface PowerCalendarDefaultBlock extends PowerCalendarAPI {
-  Nav: ComponentLike<PowerCalendarNavComponent>;
-  Days: ComponentLike<PowerCalendarDaysComponent>;
+  Nav: ComponentLike<PowerCalendarNavSignature>;
+  Days: ComponentLike<PowerCalendarDaysSignature>;
 }
 
 export type CalendarDay =

--- a/ember-power-calendar/src/components/power-calendar.ts
+++ b/ember-power-calendar/src/components/power-calendar.ts
@@ -13,8 +13,12 @@ import {
   type PowerCalendarDay,
   type SelectedPowerCalendarRange,
 } from '../utils.ts';
-import PowerCalendarNavComponent, { type PowerCalendarNavSignature } from './power-calendar/nav.ts';
-import PowerCalendarDaysComponent, { type PowerCalendarDaysSignature } from './power-calendar/days.ts';
+import PowerCalendarNavComponent, {
+  type PowerCalendarNavSignature,
+} from './power-calendar/nav.ts';
+import PowerCalendarDaysComponent, {
+  type PowerCalendarDaysSignature,
+} from './power-calendar/days.ts';
 import type Owner from '@ember/owner';
 import type PowerCalendarService from '../services/power-calendar.ts';
 import type {

--- a/ember-power-calendar/src/components/power-calendar/nav.ts
+++ b/ember-power-calendar/src/components/power-calendar/nav.ts
@@ -4,7 +4,7 @@ import type {
   TPowerCalendarMoveCenterUnit,
 } from '../power-calendar.ts';
 
-interface PowerCalendarNavSignature {
+export interface PowerCalendarNavSignature {
   Args: {
     calendar: CalendarAPI;
     format: string;


### PR DESCRIPTION
In `ComponentLike` we need to pass the signature not the component.