### PR TITLE
Typing: Remove `calendar` from default blocks (not necessary to pass)

### DIFF
--- a/ember-power-calendar/src/components/power-calendar-multiple.ts
+++ b/ember-power-calendar/src/components/power-calendar-multiple.ts
@@ -54,8 +54,15 @@ interface PowerCalendarMultipleArgs
 }
 
 interface PowerCalendarMultipleDefaultBlock extends PowerCalendarMultipleAPI {
-  Nav: ComponentLike<PowerCalendarNavSignature>;
-  Days: ComponentLike<PowerCalendarMultipleDaysSignature>;
+  Nav: ComponentLike<{
+    Args: Omit<PowerCalendarNavSignature['Args'], 'calendar'>;
+    Blocks: PowerCalendarNavSignature['Blocks'];
+  }>;
+  Days: ComponentLike<{
+    Element: PowerCalendarMultipleDaysSignature['Element'];
+    Args: Omit<PowerCalendarMultipleDaysSignature['Args'], 'calendar'>;
+    Blocks: PowerCalendarMultipleDaysSignature['Blocks'];
+  }>;
 }
 
 interface PowerCalendarMultipleSignature {

--- a/ember-power-calendar/src/components/power-calendar-range.ts
+++ b/ember-power-calendar/src/components/power-calendar-range.ts
@@ -59,8 +59,15 @@ interface PowerCalendarRangeArgs
 }
 
 export interface PowerCalendarRangeDefaultBlock extends PowerCalendarRangeAPI {
-  Nav: ComponentLike<PowerCalendarNavSignature>;
-  Days: ComponentLike<PowerCalendarRangeDaysSignature>;
+  Nav: ComponentLike<{
+    Args: Omit<PowerCalendarNavSignature['Args'], 'calendar'>;
+    Blocks: PowerCalendarNavSignature['Blocks'];
+  }>;
+  Days: ComponentLike<{
+    Element: PowerCalendarRangeDaysSignature['Element'];
+    Args: Omit<PowerCalendarRangeDaysSignature['Args'], 'calendar'>;
+    Blocks: PowerCalendarRangeDaysSignature['Blocks'];
+  }>;
 }
 
 interface PowerCalendarRangeSignature {

--- a/ember-power-calendar/src/components/power-calendar.ts
+++ b/ember-power-calendar/src/components/power-calendar.ts
@@ -89,8 +89,15 @@ export interface PowerCalendarArgs {
 }
 
 export interface PowerCalendarDefaultBlock extends PowerCalendarAPI {
-  Nav: ComponentLike<PowerCalendarNavSignature>;
-  Days: ComponentLike<PowerCalendarDaysSignature>;
+  Nav: ComponentLike<{
+    Args: Omit<PowerCalendarNavSignature['Args'], 'calendar'>;
+    Blocks: PowerCalendarNavSignature['Blocks'];
+  }>;
+  Days: ComponentLike<{
+    Element: PowerCalendarDaysSignature['Element'];
+    Args: Omit<PowerCalendarDaysSignature['Args'], 'calendar'>;
+    Blocks: PowerCalendarDaysSignature['Blocks'];
+  }>;
 }
 
 export type CalendarDay =


### PR DESCRIPTION
Discovered in my app, that the `calendar` property is right now necessary from typing, but that incorrect, because we do add it internal and so you should never pass from outside