### PR TITLE
Remove ember-source and glimmer tracking as a peer dependency

### DIFF
--- a/ember-power-calendar/package.json
+++ b/ember-power-calendar/package.json
@@ -111,9 +111,7 @@
   "peerDependencies": {
     "@ember/test-helpers": "^2.9.4 || ^3.2.1 || ^4.0.4 || ^5.0.0",
     "@glimmer/component": "^1.1.2 || ^2.0.0",
-    "@glimmer/tracking": "^1.1.2",
-    "ember-concurrency": "^4.0.2",
-    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
+    "ember-concurrency": "^4.0.2"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
- ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors
- @glimmer/tracking removed because it's a real package, but one we don't want to use. This comes up in embroider/vite where the presence of real packages always takes precedence over virtual packages. This is actually problematic because it can break reactivity in subtle ways, even if a dep graph is correct - allowing duplicates of dependencies, which for the glimmer internals, we don't want.

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35