### PR TITLE
Fix unwanted jumping when `autofocus = true`

### DIFF
--- a/src/components/power-calendar-multiple/days.gts
+++ b/src/components/power-calendar-multiple/days.gts
@@ -35,6 +35,7 @@ import { on } from '@ember/modifier';
 import emberPowerCalendarDayClasses, {
   type TDayClass,
 } from '../../helpers/ember-power-calendar-day-classes.ts';
+import { task, timeout } from 'ember-concurrency';
 import type PowerCalendarService from '../../services/power-calendar.ts';
 import type { PowerCalendarDaysArgs } from '../power-calendar/days.ts';
 
@@ -258,12 +259,13 @@ export default class PowerCalendarMultipleDays extends Component<PowerCalendarMu
 
     if (this.args.autofocus) {
       if (this.args.autofocus) {
-        queueMicrotask(() => this.initialFocus());
+        void this.initialFocus.perform();
       }
     }
   });
 
-  initialFocus() {
+  initialFocus = task(async () => {
+    await timeout(50);
     const activeDay = this.days.find((x) => x.isSelected && !x.isDisabled);
 
     if (activeDay) {
@@ -283,7 +285,7 @@ export default class PowerCalendarMultipleDays extends Component<PowerCalendarMu
     }
 
     focusDate(this.args.calendar.uniqueId, this.focusedId ?? '', this.element);
-  }
+  });
 
   async focusDay(e: MouseEvent | KeyboardEvent, date: Date, step: number = 0) {
     if (

--- a/src/components/power-calendar-range/days.gts
+++ b/src/components/power-calendar-range/days.gts
@@ -37,6 +37,7 @@ import {
 } from '../../-private/days-utils.ts';
 import { modifier } from 'ember-modifier';
 import { on } from '@ember/modifier';
+import { task, timeout } from 'ember-concurrency';
 import type { PowerCalendarDaysArgs } from '../power-calendar/days.ts';
 import type { PowerCalendarRangeAPI } from '../power-calendar-range.ts';
 import type PowerCalendarService from '../../services/power-calendar.ts';
@@ -268,12 +269,13 @@ export default class PowerCalendarRangeDays extends Component<PowerCalendarRange
 
     if (this.args.autofocus) {
       if (this.args.autofocus) {
-        queueMicrotask(() => this.initialFocus());
+        void this.initialFocus.perform();
       }
     }
   });
 
-  initialFocus() {
+  initialFocus = task(async () => {
+    await timeout(50);
     const activeDay = this.days.find((x) => x.isSelected && !x.isDisabled);
 
     if (activeDay) {
@@ -293,7 +295,7 @@ export default class PowerCalendarRangeDays extends Component<PowerCalendarRange
     }
 
     focusDate(this.args.calendar.uniqueId, this.focusedId ?? '', this.element);
-  }
+  });
 
   async focusDay(e: MouseEvent | KeyboardEvent, date: Date, step: number = 0) {
     if (

--- a/src/components/power-calendar/days.gts
+++ b/src/components/power-calendar/days.gts
@@ -34,6 +34,7 @@ import { on } from '@ember/modifier';
 import emberPowerCalendarDayClasses, {
   type TDayClass,
 } from '../../helpers/ember-power-calendar-day-classes.ts';
+import { task, timeout } from 'ember-concurrency';
 import type { PowerCalendarAPI } from '../power-calendar.ts';
 import type PowerCalendarService from '../../services/power-calendar.ts';
 
@@ -251,12 +252,14 @@ export default class PowerCalendarDays extends Component<PowerCalendarDaysSignat
 
     if (this.args.autofocus) {
       if (this.args.autofocus) {
-        queueMicrotask(() => this.initialFocus());
+        void this.initialFocus.perform();
       }
     }
   });
 
-  initialFocus() {
+  initialFocus = task(async () => {
+    await timeout(50);
+
     const activeDay = this.days.find((x) => x.isSelected && !x.isDisabled);
 
     if (activeDay) {
@@ -276,7 +279,7 @@ export default class PowerCalendarDays extends Component<PowerCalendarDaysSignat
     }
 
     focusDate(this.args.calendar.uniqueId, this.focusedId ?? '', this.element);
-  }
+  });
 
   async focusDay(e: MouseEvent | KeyboardEvent, date: Date, step: number = 0) {
     if (


### PR DESCRIPTION
Discovered in an app that there is an unwanted jump (browser scroll) when the datepicker has an animation and `autofocus = true` is set.